### PR TITLE
Log model's params

### DIFF
--- a/meta/metric_viewer.py
+++ b/meta/metric_viewer.py
@@ -46,6 +46,9 @@ class MetricViewer:
                 if 'metrics' in meta:
                     metric.update(meta['metrics'])
 
+                if 'params' in meta:
+                    metric.update(meta['params'])
+
                 self.metrics.append(metric)
         self.table = pd.DataFrame(self.metrics)
 

--- a/models/model.py
+++ b/models/model.py
@@ -28,8 +28,11 @@ class Model:
         Should be called in any successor - initializes default meta needed.
         Arguments passed in it should be related to model's hyperparameters, architecture.
         All additional arguments should have defaults.
+        Successors should pass all of their parameters to superclass for it to be able to
+        log them in meta
         """
         self.metrics = {}
+        self.params = kwargs
         self.created_at = datetime.now()
 
     def fit(self, *args, **kwargs):
@@ -68,6 +71,7 @@ class Model:
     def get_meta(self) -> List[Dict]:
         meta = [{
             'created_at': self.created_at,
-            'metrics': self.metrics
+            'metrics': self.metrics,
+            'params': self.params
         }]
         return meta


### PR DESCRIPTION
Model's metrics go into model's meta, but params don't. This change fixes that.
Now all Model successors if they pass their parameters to the Model's constructor, log them in meta automatically.