### PR TITLE
Cascade utils setup

### DIFF
--- a/cascade/__init__.py
+++ b/cascade/__init__.py
@@ -1,3 +1,19 @@
+"""
+Copyright 2022 Ilia Moiseev
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 __version__ = '0.2.1'
 __author__ = 'Ilia Moiseev'
 __author_email__ = 'ilia.moiseev.5@yandex.ru'
@@ -7,3 +23,10 @@ from . import models
 from . import meta
 
 from . import tests
+
+# cascade does not have
+# `from . import utils`
+# because it will bring additional dependencies that may not be needed by the user
+# if you need to use cascade.utils, you can insyall utils_requirements.txt and then
+# `from cascade import utils`
+# it will work

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,12 @@ setuptools.setup(
         "License :: Apache License 2.0",
         "Operating System :: OS Independent",
         'Topic :: Software Development :: Libraries :: Python Modules'
-            'Intended Audience :: Developers',
-            'Intended Audience :: Science/Research'
+        'Intended Audience :: Developers',
+        'Intended Audience :: Science/Research'
     ],
-    package_dir={"cascade": "./cascade"}, # , 'cascade_utils': './cascade/utils'
-    packages=setuptools.find_packages(), # , 'cascade_utils'
+    package_dir={"cascade": "./cascade",
+                 'cascade_utils': './cascade/utils'},
+    packages=setuptools.find_packages(),
     python_requires=">=3.8",
     install_requires=[
         'tqdm',

--- a/utils_requirements.txt
+++ b/utils_requirements.txt
@@ -1,4 +1,4 @@
 opencv-python
 pandas
 scikit-learn
-dask[dataframe]
+dask[dataframe]<2022.5.0


### PR DESCRIPTION
Add cascade utils as a separate package that will be available only with `from cascade import utils`, but not with `from cascade.utils import something`
this is done to not to bring additional dependencies to the core