### PR TITLE
Meta changes

### DIFF
--- a/cascade/meta/history_viewer.py
+++ b/cascade/meta/history_viewer.py
@@ -37,21 +37,25 @@ class HistoryViewer:
         metas = []
         self.params = []
         for name in self.repo.lines:
-            viewer_root = os.path.join(self.repo.root, name)
-            view = MetaViewer(viewer_root)
+            line = self.repo[name]
 
-            for i in range(len(view)):
-                meta = {'line': name, 'num': i}
+            i = 0
+            for path in line.model_names:
+                # Open the view of Model's meta - only one meta in View
+                view = MetaViewer(os.path.join(self.repo.root, name, os.path.dirname(path)))
+
+                new_meta = {'line': name, 'num': i}
                 # recursively unfold every nested dict to form plain table
-                self._add(view[i], meta)
-                metas.append(meta)
+                self._add(view[0], new_meta)
+                metas.append(new_meta)
 
                 params = {
                     'line': name,
                 }
-                if 'params' in view[i]:
-                    params.update(view[i]['params'])
+                if 'params' in view[0]:
+                    params.update(view[0]['params'])
                 self.params.append(params)
+                i += 1
 
         self.table = pd.DataFrame(metas)
         if 'saved_at' in self.table:

--- a/cascade/models/model.py
+++ b/cascade/models/model.py
@@ -81,18 +81,22 @@ class Model:
         all_default_exist = True
         if hasattr(self, 'created_at'):
             meta['created_at'] = self.created_at
+        else:
             all_default_exist = False
 
         if hasattr(self, 'metrics'):
             meta['metrics'] = self.metrics
+        else:
             all_default_exist = False
 
         if hasattr(self, 'params'):
             meta['params'] = self.params
+        else:
             all_default_exist = False
 
         if hasattr(self, 'meta_prefix'):
             meta.update(self.meta_prefix)
+        else:
             all_default_exist = False
 
         if not all_default_exist:

--- a/cascade/models/model_line.py
+++ b/cascade/models/model_line.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 
 import os
-import sys
+from typing import List, Dict
 import pendulum
 import glob
 from hashlib import md5
@@ -43,7 +43,6 @@ class ModelLine:
             A class of models in repo. ModelLine uses this class to reconstruct a model
         meta_prefix:
             a dict that is used to update resulting model line's meta before saving
-
         See also
         --------
         cascade.models.ModelRepo
@@ -94,6 +93,8 @@ class ModelLine:
         Folder's name is assigned using f'{idx:0>5d}'. For example: 00001 or 00042.
         The name passed to model's save is just "model" without extension.
         It is Model's responsibility to correctly  assign extension and save its own state.
+
+        Additionally, saves ModelLine's meta to the Line's root
         """
         idx = len(self.model_names)
         folder_name = f'{idx:0>5d}'
@@ -123,7 +124,7 @@ class ModelLine:
     def __repr__(self) -> str:
         return f'ModelLine of {len(self)} models of {self.model_cls}'
 
-    def get_meta(self) -> dict:
+    def get_meta(self) -> List[Dict]:
         meta = {
             'name': repr(self),
             'root': self.root,
@@ -131,5 +132,5 @@ class ModelLine:
             'len': len(self),
             'updated_at': pendulum.now(tz='UTC')
         }
-        meta.update(self.meta_prefix())
-        return meta
+        meta.update(self.meta_prefix)
+        return [meta]

--- a/cascade/models/model_line.py
+++ b/cascade/models/model_line.py
@@ -42,7 +42,7 @@ class ModelLine:
         model_cls:
             A class of models in repo. ModelLine uses this class to reconstruct a model
         meta_prefix:
-            a dict that is used to update resulting meta before saving
+            a dict that is used to update resulting model line's meta before saving
 
         See also
         --------
@@ -110,12 +110,26 @@ class ModelLine:
 
         meta = model.get_meta()[0]
 
-        meta.update(self.meta_prefix)
         meta['name'] = exact_filename
         meta['md5sum'] = md5sum
         meta['saved_at'] = pendulum.now(tz='UTC')
 
+        # Save model's meta
         self.meta_viewer.write(os.path.join(self.root, folder_name, 'meta.json'), meta)
+
+        # Save updated line's meta
+        self.meta_viewer.write(os.path.join(self.root, 'meta.json'), self.get_meta())
 
     def __repr__(self) -> str:
         return f'ModelLine of {len(self)} models of {self.model_cls}'
+
+    def get_meta(self) -> dict:
+        meta = {
+            'name': repr(self),
+            'root': self.root,
+            'model_cls': repr(self.model_cls),
+            'len': len(self),
+            'updated_at': pendulum.now(tz='UTC')
+        }
+        meta.update(self.meta_prefix())
+        return meta

--- a/cascade/models/model_repo.py
+++ b/cascade/models/model_repo.py
@@ -12,6 +12,7 @@ limitations under the License.
 """
 
 import os
+from typing import List, Dict
 import shutil
 import pendulum
 

--- a/cascade/models/model_repo.py
+++ b/cascade/models/model_repo.py
@@ -13,6 +13,7 @@ limitations under the License.
 
 import os
 import shutil
+import pendulum
 
 from .model_line import ModelLine
 
@@ -37,7 +38,6 @@ class ModelRepo:
     >>> vgg16 = VGG16Model()
     >>> vgg16.fit()
     >>> repo['vgg16'].save(vgg16)
-
     """
     def __init__(self, folder, lines=None, meta_prefix=None, overwrite=False):
         """
@@ -49,7 +49,7 @@ class ModelRepo:
         lines: List[Dict]
             A list with parameters of model lines to add at creation or to initialize (alias for `add_model`)
         meta_prefix: Dict
-            a dict that is used to update resulting meta before saving
+            a dict that is used to update resulting repo's meta before saving
         overwrite: bool
             if True will remove folder that is passed in first argument and start a new repo
             in that place
@@ -116,3 +116,13 @@ class ModelRepo:
     def __repr__(self) -> str:
         rp = f'ModelRepo in {self.root} of {len(self)} lines'
         return ', '.join([rp] + [repr(line) for line in self.lines])
+
+    def get_meta(self):
+        meta = {
+            'name': repr(self),
+            'root': self.root,
+            'len': len(self),
+            'updated_at': pendulum.now(tz='UTC')
+        }
+        meta.update(self.meta_prefix)
+        return meta

--- a/cascade/models/model_repo.py
+++ b/cascade/models/model_repo.py
@@ -17,6 +17,7 @@ import shutil
 import pendulum
 
 from .model_line import ModelLine
+from ..meta import MetaViewer
 
 
 class ModelRepo:
@@ -59,8 +60,8 @@ class ModelRepo:
         cascade.models.ModelLine
         """
         self.meta_prefix = meta_prefix if meta_prefix is not None else {}
-
         self.root = folder
+        self.meta_viewer = MetaViewer(self.root)
 
         if overwrite and os.path.exists(self.root):
             shutil.rmtree(folder)
@@ -78,10 +79,14 @@ class ModelRepo:
             for line in lines:
                 self.add_line(line['name'], line['cls'])
 
+        self.meta_viewer.write(os.path.join(self.root, 'meta.json'), self.get_meta())
+
     def add_line(self, name, model_cls):
         """
         Adds new line to repo if it doesn't exist and returns it
         If line exists, defines it in repo
+
+        Additionally, updates repo's meta on disk
         Parameters
         ----------
         model_cls:
@@ -94,6 +99,8 @@ class ModelRepo:
         folder = os.path.join(self.root, name)
         line = ModelLine(folder, model_cls=model_cls, meta_prefix=self.meta_prefix)
         self.lines[name] = line
+
+        self.meta_viewer.write(os.path.join(self.root, 'meta.json'), self.get_meta())
         return line
 
     def __getitem__(self, key) -> ModelLine:

--- a/cascade/models/model_repo.py
+++ b/cascade/models/model_repo.py
@@ -28,7 +28,7 @@ class ModelRepo:
     Example
     -------
     >>> from cascade.models import ModelRepo
-    >>> repo = ModelRepo('repo')
+    >>> repo = ModelRepo('repo', meta_prefix={'description': 'This is VGG16 model from the example.'})
     >>> vgg16_line = repo.add_line('vgg16', VGG16Model)
     >>> vgg16 = VGG16Model()
     >>> vgg16.fit()

--- a/cascade/models/model_repo.py
+++ b/cascade/models/model_repo.py
@@ -117,7 +117,7 @@ class ModelRepo:
         rp = f'ModelRepo in {self.root} of {len(self)} lines'
         return ', '.join([rp] + [repr(line) for line in self.lines])
 
-    def get_meta(self):
+    def get_meta(self) -> List[Dict]:
         meta = {
             'name': repr(self),
             'root': self.root,
@@ -125,4 +125,4 @@ class ModelRepo:
             'updated_at': pendulum.now(tz='UTC')
         }
         meta.update(self.meta_prefix)
-        return meta
+        return [meta]

--- a/cascade/tests/test_history_viewer.py
+++ b/cascade/tests/test_history_viewer.py
@@ -100,11 +100,11 @@ class TestHistoryViewer(TestCase):
         shutil.rmtree('./test_empty')
 
     def test_many_lines(self):
-        repo = ModelRepo('./test_many_lines',
-            lines=[dict(
+        repo = ModelRepo('./test_many_lines', lines=[
+            dict(
                 name=str(num),
                 cls=DummyModel) for num in range(50)
-                ])
+            ])
 
         model0 = DummyModel(a=0)
         model0.evaluate()

--- a/cascade/tests/test_model_line.py
+++ b/cascade/tests/test_model_line.py
@@ -17,6 +17,7 @@ limitations under the License.
 import os
 import sys
 import unittest
+import shutil
 from unittest import TestCase
 
 MODULE_PATH = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
@@ -28,8 +29,6 @@ from cascade.models.model_repo import ModelLine
 
 class TestModelLine(TestCase):
     def test_save_load(self):
-        import shutil
-
         line = ModelLine('./line', DummyModel)
 
         m = DummyModel()
@@ -42,6 +41,19 @@ class TestModelLine(TestCase):
 
         self.assertEqual(len(line), 1)
         self.assertTrue(model.model == "b'model'")
+
+    def test_meta(self):
+        line = ModelLine('line_meta', DummyModel)
+
+        m = DummyModel()
+
+        line.save(m)
+
+        shutil.rmtree('./line_meta')  # Cleanup
+
+        meta = line.get_meta()
+        self.assertEqual(meta[0]['model_cls'], repr(DummyModel))
+        self.assertEqual(meta[0]['len'], 1)
 
 
 if __name__ == '__main__':

--- a/cascade/tests/test_model_repo.py
+++ b/cascade/tests/test_model_repo.py
@@ -26,8 +26,6 @@ from cascade.tests.dummy_model import DummyModel
 
 class TestModelRepo(TestCase):
     def test_repo(self):
-        import shutil
-
         repo = ModelRepo('./test_models')
         repo.add_line('dummy_1', DummyModel)
         repo.add_line('00001', DummyModel)
@@ -39,8 +37,6 @@ class TestModelRepo(TestCase):
         self.assertEqual(2, len(repo))
 
     def test_overwrite(self):
-        import shutil
-
         # If no overwrite repo will have 4 models
         repo = ModelRepo('./test_overwrite', overwrite=True)
         repo.add_line('vgg16', DummyModel)
@@ -92,6 +88,16 @@ class TestModelRepo(TestCase):
 
         shutil.rmtree('./test_reusage_init_alias')
         self.assertEqual(len(repo['vgg16']), 1)
+
+    def test_meta(self):
+        repo = ModelRepo('./test_repo_meta')
+        repo.add_line('00000', DummyModel)
+        repo.add_line('00001', DummyModel)
+
+        shutil.rmtree('./test_repo_meta')  # Cleanup
+
+        meta = repo.get_meta()
+        self.assertEqual(meta[0]['len'], 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`ModelLine` and `ModelRepo` are now have `get_meta` and their own `meta.json` files.
Previously they passed their prefixes to the Models, but now they are saving their own metas in their respected folders