### PR TITLE
Refine meta

### DIFF
--- a/cascade/data/concatenator.py
+++ b/cascade/data/concatenator.py
@@ -67,6 +67,7 @@ class Concatenator(Dataset):
         Concatenator calls `get_meta()` of all its datasets and appends to its own meta
         """
         meta = super().get_meta()
+        meta[0]['data'] = []
         for ds in self._datasets:
-            meta += ds.get_meta()
+            meta[0]['data'] += ds.get_meta()
         return meta

--- a/cascade/utils/table_dataset.py
+++ b/cascade/utils/table_dataset.py
@@ -47,8 +47,8 @@ class TableDataset(Dataset):
         meta = super().get_meta()
         meta[0].update({
                 'name': repr(self),
-                'columns': str(self._table.columns),
-                'size': len(self),
+                'columns': list(self._table.columns),
+                'len': len(self),
                 'info': str(self._table.describe())
             })
         return meta

--- a/cascade/utils/table_dataset.py
+++ b/cascade/utils/table_dataset.py
@@ -49,7 +49,7 @@ class TableDataset(Dataset):
                 'name': repr(self),
                 'columns': list(self._table.columns),
                 'len': len(self),
-                'info': str(self._table.describe())
+                'info': self._table.describe().to_dict()
             })
         return meta
 


### PR DESCRIPTION
TableDataset's meta is improved:
  - columns are now just list as they should be
  - size is now len to conform with datasets key
  - info is now human-readable dict
 
Concatenator's meta improved:
  - concatenated dataset's meta is now nested and not flat