### PR TITLE
Fix meta viewer

### DIFF
--- a/cascade/data/dataset.py
+++ b/cascade/data/dataset.py
@@ -45,7 +45,10 @@ class Dataset(Generic[T]):
             Meta can be anything that is worth to document about the dataset and its data.
             This is done in form of list to enable cascade-like calls in Modifiers and Samplers.
         """
-        meta = {'name': repr(self)}
+        meta = {
+            'name': repr(self), 
+            'type': 'dataset'
+        }
         if self.meta_prefix is not None:
             meta.update(self.meta_prefix)
         return [meta]
@@ -95,7 +98,7 @@ class Wrapper(Dataset):
     def get_meta(self):
         meta = super().get_meta()
         meta[0]['len'] = len(self)
-        meta[0]['type'] = type(self.obj)
+        meta[0]['obj_type'] = type(self.obj)
 
 
 class Modifier(Dataset):

--- a/cascade/meta/meta_viewer.py
+++ b/cascade/meta/meta_viewer.py
@@ -102,7 +102,7 @@ class MetaViewer:
         meta = meta[-1]  # Takes last meta
         for key in self.filt:
             if key not in meta:
-                raise KeyError(f'{key} not in\n{meta}')
+                raise KeyError(f"'{key}' key is not in\n{meta}")
             
             if self.filt[key] != meta[key]:
                 return False

--- a/cascade/meta/meta_viewer.py
+++ b/cascade/meta/meta_viewer.py
@@ -22,7 +22,7 @@ class MetaViewer:
     """
     The class to read and write meta data.
     """
-    def __init__(self, root) -> None:
+    def __init__(self, root, filt=None) -> None:
         """
         Parameters
         ----------
@@ -36,6 +36,7 @@ class MetaViewer:
         """
         assert os.path.exists(root)
         self.root = root
+        self.filt = filt
         self.mh = MetaHandler()
 
         names = []
@@ -45,6 +46,8 @@ class MetaViewer:
         self.metas = []
         for name in names:
             self.metas.append(self.mh.read(name))
+        if filt is not None:
+            self.metas = list(filter(self._filter, self.metas))
 
     def __getitem__(self, index) -> dict:
         """
@@ -94,3 +97,13 @@ class MetaViewer:
         Loads object from path
         """
         return self.mh.read(path)
+
+    def _filter(self, meta):
+        meta = meta[-1]  # Takes last meta
+        for key in self.filt:
+            if key not in meta:
+                raise KeyError(f'{key} not in\n{meta}')
+            
+            if self.filt[key] != meta[key]:
+                return False
+        return True

--- a/cascade/meta/metric_viewer.py
+++ b/cascade/meta/metric_viewer.py
@@ -15,12 +15,14 @@ limitations under the License.
 """
 
 import os
+import warnings
 from plotly import graph_objects as go
 import pandas as pd
 import dash
 from dash import Input, Output, html, dcc
 
 from . import MetaViewer
+from .. import __version__
 
 
 class MetricViewer:
@@ -43,10 +45,20 @@ class MetricViewer:
             line = self.repo[name]
             viewer_root = os.path.join(self.repo.root, name)
 
-            for i, model_name in enumerate(line.model_names):
-                view = MetaViewer(os.path.join(viewer_root, os.path.dirname(model_name)))
+            # Try to use viewer only on models using type key
+            try:
+                view = MetaViewer(viewer_root, filt={'type': 'model'})
+            except KeyError:
+                view = [MetaViewer(os.path.join(viewer_root, os.path.dirname(model_name))) 
+                    for model_name in line.model_names]
+
+                warnings.warn('''You use cascade {__version__} with the repo generated in version <= 0.4.1 without "type": "repo" key in meta.
+                Consider updating your repo's meta by opening it with ModelRepo constructor in new version or manually.
+                In the following versions it will be deprecated.''', FutureWarning)
+
+            for i in range(len(line.model_names)):
                 metric = {'line': name, 'num': i}
-                meta = view[0][-1]
+                meta = view[i][-1]
 
                 if 'metrics' in meta:
                     metric.update(meta['metrics'])

--- a/cascade/models/model.py
+++ b/cascade/models/model.py
@@ -101,4 +101,6 @@ class Model:
 
         if not all_default_exist:
             warnings.warn('Model\'s meta is incomplete, maybe you haven\'t call super().__init__ in subclass?')
+        
+        meta['type'] = 'model'
         return [meta]

--- a/cascade/models/model_line.py
+++ b/cascade/models/model_line.py
@@ -136,7 +136,8 @@ class ModelLine:
             'root': self.root,
             'model_cls': repr(self.model_cls),
             'len': len(self),
-            'updated_at': pendulum.now(tz='UTC')
+            'updated_at': pendulum.now(tz='UTC'),
+            'type': 'line'
         }
         meta.update(self.meta_prefix)
         return [meta]

--- a/cascade/models/model_repo.py
+++ b/cascade/models/model_repo.py
@@ -145,7 +145,8 @@ class ModelRepo:
             'name': repr(self),
             'root': self.root,
             'len': len(self),
-            'updated_at': pendulum.now(tz='UTC')
+            'updated_at': pendulum.now(tz='UTC'),
+            'type': 'repo'
         }
         meta.update(self.meta_prefix)
         return [meta]


### PR DESCRIPTION
`MetaViewer` was built to easily access all meta in folder with interface of list.
After addition of repo's and line's meta its functionality was used in somewhat ugly way...
Now the new backward-compatible way of usage is proposed with FutureWarning for all old repos