### PR TITLE
Debug num in mv

### DIFF
--- a/cascade/meta/meta_viewer.py
+++ b/cascade/meta/meta_viewer.py
@@ -41,8 +41,9 @@ class MetaViewer:
         self.mh = MetaHandler()
 
         names = []
-        for root, dirs, files in os.walk(self.root):
-            names += [os.path.join(root, name) for name in sorted(files) if os.path.splitext(name)[-1] == '.json']
+        for root, _, files in os.walk(self.root):
+            names += [os.path.join(root, name) for name in files if os.path.splitext(name)[-1] == '.json']
+        names = sorted(names)
 
         self.metas = []
         for name in names:

--- a/cascade/tests/__init__.py
+++ b/cascade/tests/__init__.py
@@ -1,0 +1,1 @@
+from .conftest import OnesModel, DummyModel

--- a/cascade/tests/test_meta_viewer.py
+++ b/cascade/tests/test_meta_viewer.py
@@ -22,6 +22,8 @@ MODULE_PATH = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
 sys.path.append(os.path.dirname(MODULE_PATH))
 
 from cascade.meta import MetaViewer
+from cascade.models import ModelRepo
+from cascade.tests import DummyModel
 
 
 def test(tmp_path):
@@ -42,3 +44,23 @@ def test(tmp_path):
     assert('name' in mv[1])
     assert(mv[0]['name'] == 'test0')
     assert(mv[1]['name'] == 'test1')
+
+
+def test_order(tmp_path):
+    tmp_path = str(tmp_path)
+    repo = ModelRepo(tmp_path)
+    repo.add_line('line1', DummyModel)
+
+    for i in range(3):
+        model = DummyModel(real_num=i)
+        repo['line1'].save(model)
+
+    mv = MetaViewer(tmp_path)
+    k = 0
+
+    # This checks that models were read in exactly same order as they were saved
+    # real_num should be [0, 1, 2]
+    for meta in mv:
+        if meta[0]['type'] == 'model':
+            assert meta[0]['params']['real_num'] == k
+            k += 1


### PR DESCRIPTION
Num in MetricViewer is now model identifier. On Linux systems there was a bug with random assignment of num in MetricViewer's table. Not it is fixed - test added.