### PR TITLE
Model line only meta

### DIFF
--- a/cascade/models/model_line.py
+++ b/cascade/models/model_line.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import os
+import warnings
 from typing import List, Dict
 import pendulum
 import glob
@@ -56,15 +57,17 @@ class ModelLine(Traceable):
         self.root = folder
         self.model_names = []
         if os.path.exists(self.root):
-            assert os.path.isdir(self.root)
-            for root, _, files in os.walk(self.root):
-                model_dir = os.path.split(root)[-1]
-                self.model_names \
-                    += [os.path.join(model_dir, name)
-                        for name in files
-                        if os.path.splitext(name)[0] == 'model']
-                self.model_names = sorted(self.model_names)
+            assert os.path.isdir(self.root), f'folder should be directory, got `{folder}`'
+            self.model_names = sorted(
+                [d for d in os.listdir(self.root) 
+                    if os.path.isdir(os.path.join(self.root, d))])
+
+            if len(self.model_names) == 0:
+                warnings.warn('Model folders were not found by the line. It may be that '
+                              'you are using new version of cascade with old repos '
+                              'created before version 0.2.0')
         else:
+            # No folder -> create
             os.mkdir(self.root)
         self.meta_viewer = MetaViewer(self.root)
 

--- a/cascade/models/model_line.py
+++ b/cascade/models/model_line.py
@@ -113,19 +113,23 @@ class ModelLine(Traceable):
         idx = len(self.model_names)
         folder_name = f'{idx:0>5d}'
         full_path = os.path.join(self.root, folder_name, 'model')
-        self.model_names.append(os.path.join(folder_name, 'model'))
 
+        # Create model's folder if no
         os.makedirs(os.path.join(self.root, folder_name), exist_ok=True)
+
+        # Prepare meta for saving
         meta = model.get_meta()
+
         if not only_meta:
+            # Save model
             model.save(full_path)
 
             # Find anything that matches /path/model_folder/model*
             exact_filename = glob.glob(f'{full_path}*')
 
-            assert len(exact_filename) > 0, 'Model file was\'nt found.\n \
-                It may be that Model didn\'t save itself, or the name of the file \
-                    didn\'t match "model*"'
+            assert len(exact_filename) > 0, 'Model file was\'nt found.\n '
+            'It may be that Model didn\'t save itself when save() was called,'
+            'or the name of the file didn\'t match "model*"'
 
             exact_filename = exact_filename[0]
             with open(exact_filename, 'rb') as f:
@@ -133,7 +137,9 @@ class ModelLine(Traceable):
 
             meta[-1]['name'] = exact_filename
             meta[-1]['md5sum'] = md5sum
+
         meta[-1]['saved_at'] = pendulum.now(tz='UTC')
+        self.model_names.append(os.path.join(folder_name, 'model'))
 
         # Save model's meta
         self.meta_viewer.write(os.path.join(self.root, folder_name, 'meta' + self.meta_fmt), meta)

--- a/cascade/models/model_line.py
+++ b/cascade/models/model_line.py
@@ -56,8 +56,8 @@ class ModelLine(Traceable):
         self.root = folder
         self.model_names = []
         if os.path.exists(self.root):
-            assert os.path.isdir(folder)
-            for root, dirs, files in os.walk(self.root):
+            assert os.path.isdir(self.root)
+            for root, _, files in os.walk(self.root):
                 model_dir = os.path.split(root)[-1]
                 self.model_names \
                     += [os.path.join(model_dir, name)


### PR DESCRIPTION
- Drops the support of early version repos with warning (<= 0.2.0)
- Adds the ability to save models without binaries (only_meta)