### PR TITLE
More reliable repos

### DIFF
--- a/cascade/base/meta_handler.py
+++ b/cascade/base/meta_handler.py
@@ -29,6 +29,7 @@ class CustomEncoder(JSONEncoder):
     def default(self, obj):
         if isinstance(obj, type):
             return str(obj)
+
         if isinstance(obj, (datetime.datetime, datetime.date, datetime.time)):
             return obj.isoformat()
 
@@ -68,6 +69,12 @@ class BaseHandler:
     def write(self, path, obj, overwrite=True) -> None:
         raise NotImplementedError()
 
+    def _raise_io_error(self, path, exc):
+        # Any file decoding errors will be
+        # prepended with filepath for user
+        # to be able to identify broken file
+        raise IOError(f'Error while reading file `{path}`') from exc
+
 
 class JSONHandler(BaseHandler):
     """
@@ -81,18 +88,26 @@ class JSONHandler(BaseHandler):
         ----------
         path:
             Path to the file. If no extension provided, then .json will be added
+
+        Raises
+        ------
+        IOError
+            when decoding errors occur
         """
         _, ext = os.path.splitext(path)
         if ext == '':
             path += '.json'
 
         with open(path, 'r') as meta_file:
-            meta = json.load(meta_file)
-            if isinstance(meta, str):
-                meta = json.loads(meta)
+            try:
+                meta = json.load(meta_file)
+                if isinstance(meta, str):
+                    meta = json.loads(meta)
+            except json.JSONDecodeError as e:
+                self._raise_io_error(path, e)
             return meta
 
-    def write(self, name, obj:List[Dict], overwrite=True) -> None:
+    def write(self, name, obj: List[Dict], overwrite=True) -> None:
         """
         Writes json to path using custom encoder
         """
@@ -112,13 +127,21 @@ class YAMLHandler(BaseHandler):
         ----------
         path:
             Path to the file. If no extension provided, then .yml will be added
+        
+        Raises
+        ------
+        IOError
+            when decoding errors occur
         """
         _, ext = os.path.splitext(path)
         if ext == '':
             path += '.yml'
 
         with open(path, 'r') as meta_file:
-            meta = yaml.safe_load(meta_file)
+            try:
+                meta = yaml.safe_load(meta_file)
+            except yaml.YAMLError as e:
+                self._raise_io_error(path, e)
             return meta
 
     def write(self, path, obj, overwrite=True) -> None:

--- a/cascade/meta/meta_viewer.py
+++ b/cascade/meta/meta_viewer.py
@@ -23,7 +23,7 @@ class MetaViewer:
     """
     The class to read and write meta data.
     """
-    def __init__(self, root, filt=None) -> None:
+    def __init__(self, root, filt=None, meta_fmt='.json') -> None:
         """
         Parameters
         ----------
@@ -40,13 +40,15 @@ class MetaViewer:
         cascade.meta.MetaHandler
         """
         assert os.path.exists(root)
+        assert meta_fmt in ('.json', '.yml')
         self._root = root
         self._filt = filt
+        self._meta_fmt = meta_fmt
         self._mh = MetaHandler()
 
         names = []
         for root, _, files in os.walk(self._root):
-            names += [os.path.join(root, name) for name in files if os.path.splitext(name)[-1] == '.json']
+            names += [os.path.join(root, name) for name in files if os.path.splitext(name)[-1] == self._meta_fmt]
         names = sorted(names)
 
         self.metas = []

--- a/cascade/meta/meta_viewer.py
+++ b/cascade/meta/meta_viewer.py
@@ -39,8 +39,11 @@ class MetaViewer:
         cascade.meta.ModelRepo
         cascade.meta.MetaHandler
         """
+        supported_formats = ('.json', '.yml')
+
         assert os.path.exists(root)
-        assert meta_fmt in ('.json', '.yml')
+        assert meta_fmt in supported_formats, f'Only {supported_formats} are supported formats'
+
         self._root = root
         self._filt = filt
         self._meta_fmt = meta_fmt

--- a/cascade/meta/meta_viewer.py
+++ b/cascade/meta/meta_viewer.py
@@ -46,16 +46,13 @@ class MetaViewer:
         self._meta_fmt = meta_fmt
         self._mh = MetaHandler()
 
-        names = []
+        self.names = []
         for root, _, files in os.walk(self._root):
-            names += [os.path.join(root, name) for name in files if os.path.splitext(name)[-1] == self._meta_fmt]
-        names = sorted(names)
+            self.names += [os.path.join(root, name) for name in files if os.path.splitext(name)[-1] == self._meta_fmt]
+        self.names = sorted(self.names)
 
-        self.metas = []
-        for name in names:
-            self.metas.append(self._mh.read(name))
         if filt is not None:
-            self.metas = list(filter(self._filter, self.metas))
+            self.names = list(filter(self._filter, self.names))
 
     def __getitem__(self, index) -> List[Dict]:
         """
@@ -64,41 +61,17 @@ class MetaViewer:
         meta: List[Dict]
             object containing meta
         """
-        return self.metas[index]
+        return self.read(self.names[index])
 
     def __len__(self) -> int:
-        return len(self.metas)
+        return len(self.names)
 
-    def __repr__(self) -> str:
-        def pretty(d, indent=0, sep=' '):
-            out = ''
-            for key in d:
-                if isinstance(d, dict):
-                    value = d[key]
-                    out += sep * indent + str(key) + ':\n'
-                else:
-                    value = key
-                if isinstance(value, dict) or isinstance(value, list):
-                    out += pretty(value, indent + 1)
-                else:
-                    out += sep * (indent + 1) + str(value) + sep
-                    out += '\n'
-            return out
-
-        out = f'MetaViewer at {self._root}:\n'
-        for i, meta in enumerate(self.metas):
-            out += '-' * 20 + '\n'
-            out += f'  Meta {i}:\n'
-            out += '-' * 20 + '\n'
-            out += pretty(meta, 4)
-        return out
-
-    def write(self, name, obj: List[Dict]) -> None:
+    def write(self, path, obj: List[Dict]) -> None:
         """
-       Dumps obj to name
-       """
-        self.metas.append(obj)
-        self._mh.write(name, obj)
+        Dumps obj to path
+        """
+        # self.metas.append(obj)
+        self._mh.write(path, obj)
 
     def read(self, path) -> List[Dict]:
         """
@@ -106,7 +79,8 @@ class MetaViewer:
         """
         return self._mh.read(path)
 
-    def _filter(self, meta):
+    def _filter(self, name):
+        meta = self.read(name)
         meta = meta[-1]  # Takes last meta
         for key in self._filt:
             if key not in meta:

--- a/cascade/models/model_line.py
+++ b/cascade/models/model_line.py
@@ -60,8 +60,9 @@ class ModelLine(Traceable):
         if os.path.exists(self.root):
             assert os.path.isdir(self.root), f'folder should be directory, got `{folder}`'
             self.model_names = sorted(
-                [d for d in os.listdir(self.root) 
-                    if os.path.isdir(os.path.join(self.root, d))])
+                [os.path.join(model_folder, 'model')
+                    for model_folder in os.listdir(self.root)
+                    if os.path.isdir(os.path.join(self.root, model_folder))])
 
             if len(self.model_names) == 0:
                 warnings.warn('Model folders were not found by the line. It may be that '

--- a/cascade/models/model_line.py
+++ b/cascade/models/model_line.py
@@ -51,7 +51,7 @@ class ModelLine(Traceable):
         """
         super().__init__(**kwargs)
 
-        assert meta_fmt in ['.json', '.yml'], 'Only .json or .yml are supported formats'
+        assert meta_fmt in ('.json', '.yml'), 'Only .json or .yml are supported formats'
         self._meta_fmt = meta_fmt
         self._model_cls = model_cls
         self.root = folder
@@ -69,7 +69,7 @@ class ModelLine(Traceable):
         else:
             # No folder -> create
             os.mkdir(self.root)
-        self.meta_viewer = MetaViewer(self.root)
+        self.meta_viewer = MetaViewer(self.root, meta_fmt=self._meta_fmt)
 
     def __getitem__(self, num) -> Model:
         """

--- a/cascade/models/model_line.py
+++ b/cascade/models/model_line.py
@@ -51,7 +51,8 @@ class ModelLine(Traceable):
         """
         super().__init__(**kwargs)
 
-        assert meta_fmt in ('.json', '.yml'), 'Only .json or .yml are supported formats'
+        supported_formats = ('.json', '.yml')
+        assert meta_fmt in supported_formats, f'Only {supported_formats} are supported formats'
         self._meta_fmt = meta_fmt
         self._model_cls = model_cls
         self.root = folder

--- a/cascade/models/model_repo.py
+++ b/cascade/models/model_repo.py
@@ -11,6 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import warnings
 import itertools
 import os
 import logging
@@ -172,7 +173,10 @@ class ModelRepo(Repo):
 
         meta = {}
         if os.path.exists(meta_path):
-            meta = self._mev.read(meta_path)[0]
+            try:
+                meta = self._mev.read(meta_path)[0]
+            except IOError as e:
+                warnings.warn(f'File reading error ignored: {e}')
 
         self.logger.info(DeepDiff(
             meta,
@@ -180,7 +184,10 @@ class ModelRepo(Repo):
         )
 
         meta.update(self.get_meta()[0])
-        self._mev.write(meta_path, [meta])
+        try:
+            self._mev.write(meta_path, [meta])
+        except IOError as e:
+            warnings.warn(f'File writing error ignored: {e}')
 
     def get_meta(self) -> List[Dict]:
         meta = super().get_meta()

--- a/cascade/models/model_repo.py
+++ b/cascade/models/model_repo.py
@@ -127,9 +127,10 @@ class ModelRepo(Repo):
         model_cls:
             A class of models in line. ModelLine uses this class to reconstruct a model
         name:
-            Line's name
+            Line's name. It will be used to name a folder of line.
        """
-        assert type(model_cls) == type, f'You should pass model\'s class, not {type(model_cls)}'
+        assert type(model_cls) == type, f'model_cls argument should be model\'s class, \
+            however `{type(model_cls)}` is received'
 
         folder = os.path.join(self.root, name)
         line = ModelLine(folder, model_cls=model_cls, meta_prefix=self._meta_prefix, **kwargs)

--- a/cascade/tests/test_meta_handler.py
+++ b/cascade/tests/test_meta_handler.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 import os
 import sys
+from json import JSONDecodeError
 import pendulum
 import numpy as np
 import pytest
@@ -36,18 +37,18 @@ def test(tmp_path, ext):
     tmp_path = str(tmp_path)
     mh = MetaHandler()
     mh.write(os.path.join(tmp_path, 'meta' + ext),
-    {
-        'name': 'test_mh',
-        'array': np.zeros(4),
-        'none': None,
-        'date': pendulum.now(tz='UTC')
-    })
+             {
+                 'name': 'test_mh',
+                 'array': np.zeros(4),
+                 'none': None,
+                 'date': pendulum.now(tz='UTC')
+             })
 
     obj = mh.read(os.path.join(tmp_path, 'meta' + ext))
 
-    assert(obj['name'] == 'test_mh')
-    assert(obj['array'] == [0, 0, 0, 0])
-    assert(obj['none'] is None)
+    assert (obj['name'] == 'test_mh')
+    assert (obj['array'] == [0, 0, 0, 0])
+    assert (obj['none'] is None)
 
 
 @pytest.mark.parametrize(
@@ -61,17 +62,17 @@ def test_overwrite(tmp_path, ext):
 
     mh = MetaHandler()
     mh.write(
-        tmp_path, 
+        tmp_path,
         {'name': 'first'},
         overwrite=False)
 
     mh.write(
-        tmp_path, 
+        tmp_path,
         {'name': 'second'},
         overwrite=False)
 
     obj = mh.read(tmp_path)
-    assert(obj['name'] == 'first')
+    assert (obj['name'] == 'first')
 
 
 @pytest.mark.parametrize(
@@ -90,4 +91,41 @@ def test_text(tmp_path, ext):
 
     obj = mh.read(tmp_path)
 
-    assert(obj[tmp_path] == info)
+    assert (obj[tmp_path] == info)
+
+
+@pytest.mark.parametrize(
+    'ext', [
+        '.json',
+        '.yml',
+        '.txt',
+        '.md'
+    ]
+)
+def test_not_exist(ext):
+    mh = MetaHandler()
+
+    # The case of non-existing file
+    with pytest.raises(IOError) as e:
+        mh.read('this_file_does_not_exist' + ext)
+    assert e.typename == 'FileNotFoundError'
+
+
+@pytest.mark.parametrize(
+    'ext', [
+        '.json',
+        '.yml'
+    ]
+)
+def test_read_fail(tmp_path, ext):
+    tmp_path = str(tmp_path)
+    mh = MetaHandler()
+
+    # Simulate broken syntax in file
+    filename = os.path.join(tmp_path, 'meta' + ext)
+    with open(filename, 'w') as f:
+        f.write('\t{\t :this file is broken')
+
+    with pytest.raises(IOError) as e:
+        mh.read(filename)
+    assert filename in e.value.args[0]

--- a/cascade/tests/test_meta_handler.py
+++ b/cascade/tests/test_meta_handler.py
@@ -126,6 +126,7 @@ def test_read_fail(tmp_path, ext):
     with open(filename, 'w') as f:
         f.write('\t{\t :this file is broken')
 
+    # Test that file path is in error message
     with pytest.raises(IOError) as e:
         mh.read(filename)
     assert filename in e.value.args[0]

--- a/cascade/tests/test_meta_viewer.py
+++ b/cascade/tests/test_meta_viewer.py
@@ -35,19 +35,19 @@ def test(tmp_path):
         json.dump({'name': 'test0'}, f)
 
     # Write also using mev
-    mv = MetaViewer(tmp_path)
-    mv.write(os.path.join(tmp_path, 'model', 'test1.json'), {'name': 'test1'})    
+    mev = MetaViewer(tmp_path)
+    mev.write(os.path.join(tmp_path, 'model', 'test1.json'), {'name': 'test1'})    
 
-    mv = MetaViewer(tmp_path)
+    mev = MetaViewer(tmp_path)
 
-    assert(len(mv) == 2)
-    assert('name' in mv[0])
-    assert('name' in mv[1])
+    assert(len(mev) == 2)
+    assert('name' in mev[0])
+    assert('name' in mev[1])
 
     # This order is due to sorting by path
     # .../model/test1.json is less than .../test0.json
-    assert(mv[0]['name'] == 'test1')
-    assert(mv[1]['name'] == 'test0')
+    assert(mev[0]['name'] == 'test1')
+    assert(mev[1]['name'] == 'test0')
 
 
 def test_order(tmp_path):
@@ -59,12 +59,12 @@ def test_order(tmp_path):
         model = DummyModel(real_num=i)
         repo['line1'].save(model)
 
-    mv = MetaViewer(tmp_path)
+    mev = MetaViewer(tmp_path)
     k = 0
 
     # This checks that models were read in exactly same order as they were saved
     # real_num should be [0, 1, 2]
-    for meta in mv:
+    for meta in mev:
         if meta[0]['type'] == 'model':
             assert meta[0]['params']['real_num'] == k
             k += 1

--- a/cascade/tests/test_model_repo.py
+++ b/cascade/tests/test_model_repo.py
@@ -222,3 +222,81 @@ def test_missing_model_meta(tmp_path, ext):
     repo = ModelRepo(repo_path, lines=[
         dict(name='0', model_cls=DummyModel, meta_fmt=ext)])
     model = repo['0'][0]
+
+
+@pytest.mark.parametrize(
+    'ext', [
+        '.json'
+    ]
+)
+def test_failed_repo_meta(tmp_path, ext):
+    tmp_path = str(tmp_path)
+    repo_path = os.path.join(tmp_path, 'repo')
+    repo = ModelRepo(repo_path)
+    repo.add_line('0', DummyModel, meta_fmt=ext)
+
+    model = DummyModel()
+
+    repo['0'].save(model)
+
+    # simulate failed meta
+    meta_path = os.path.join(repo_path, 'meta' + ext)
+    assert os.path.exists(meta_path)
+    with open(meta_path, 'w') as f:
+        f.write("\t{{{: 'sorry, i am broken'")
+
+    repo = ModelRepo(repo_path, lines=[
+        dict(name='0', model_cls=DummyModel, meta_fmt=ext)])
+    model = repo['0'][0]
+
+
+@pytest.mark.parametrize(
+    'ext', [
+        '.json'
+    ]
+)
+def test_failed_line_meta(tmp_path, ext):
+    tmp_path = str(tmp_path)
+    repo_path = os.path.join(tmp_path, 'repo')
+    repo = ModelRepo(repo_path)
+    repo.add_line('0', DummyModel, meta_fmt=ext)
+
+    model = DummyModel()
+
+    repo['0'].save(model)
+
+    # simulate failed meta
+    meta_path = os.path.join(repo_path, '0', 'meta' + ext)
+    assert os.path.exists(meta_path)
+    with open(meta_path, 'w') as f:
+        f.write("\t{{{: 'sorry, i am broken'")
+
+    repo = ModelRepo(repo_path, lines=[
+        dict(name='0', model_cls=DummyModel, meta_fmt=ext)])
+    model = repo['0'][0]
+
+
+@pytest.mark.parametrize(
+    'ext', [
+        '.json'
+    ]
+)
+def test_failed_model_meta(tmp_path, ext):
+    tmp_path = str(tmp_path)
+    repo_path = os.path.join(tmp_path, 'repo')
+    repo = ModelRepo(repo_path)
+    repo.add_line('0', DummyModel, meta_fmt=ext)
+
+    model = DummyModel()
+
+    repo['0'].save(model)
+
+    # simulate failed meta
+    meta_path = os.path.join(repo_path, '0', '00000', 'meta' + ext)
+    assert os.path.exists(meta_path)
+    with open(meta_path, 'w') as f:
+        f.write("\t{{{: 'sorry, i am broken'")
+
+    repo = ModelRepo(repo_path, lines=[
+        dict(name='0', model_cls=DummyModel, meta_fmt=ext)])
+    model = repo['0'][0]

--- a/cascade/tests/test_model_repo.py
+++ b/cascade/tests/test_model_repo.py
@@ -178,7 +178,8 @@ def test_add(tmp_path):
 
 @pytest.mark.parametrize(
     'ext', [
-        '.json'
+        '.json',
+        '.yml'
     ]
 )
 def test_missing_repo_meta(tmp_path, ext):
@@ -202,14 +203,15 @@ def test_missing_repo_meta(tmp_path, ext):
 
 @pytest.mark.parametrize(
     'ext', [
-        '.json'
+        '.json',
+        '.yml'
     ]
 )
 def test_missing_line_meta(tmp_path, ext):
     tmp_path = str(tmp_path)
     repo_path = os.path.join(tmp_path, 'repo')
-    repo = ModelRepo(repo_path)
-    repo.add_line('0', DummyModel, meta_fmt=ext)
+    repo = ModelRepo(repo_path, meta_fmt=ext)
+    repo.add_line('0', DummyModel)
 
     model = DummyModel()
 
@@ -226,14 +228,15 @@ def test_missing_line_meta(tmp_path, ext):
 
 @pytest.mark.parametrize(
     'ext', [
-        '.json'
+        '.json',
+        '.yml'
     ]
 )
 def test_missing_model_meta(tmp_path, ext):
     tmp_path = str(tmp_path)
     repo_path = os.path.join(tmp_path, 'repo')
-    repo = ModelRepo(repo_path)
-    repo.add_line('0', DummyModel, meta_fmt=ext)
+    repo = ModelRepo(repo_path, meta_fmt=ext)
+    repo.add_line('0', DummyModel)
 
     model = DummyModel()
 
@@ -250,14 +253,15 @@ def test_missing_model_meta(tmp_path, ext):
 
 @pytest.mark.parametrize(
     'ext', [
-        '.json'
+        '.json',
+        '.yml'
     ]
 )
 def test_failed_repo_meta(tmp_path, ext):
     tmp_path = str(tmp_path)
     repo_path = os.path.join(tmp_path, 'repo')
-    repo = ModelRepo(repo_path)
-    repo.add_line('0', DummyModel, meta_fmt=ext)
+    repo = ModelRepo(repo_path, meta_fmt=ext)
+    repo.add_line('0', DummyModel)
 
     model = DummyModel()
 
@@ -276,14 +280,15 @@ def test_failed_repo_meta(tmp_path, ext):
 
 @pytest.mark.parametrize(
     'ext', [
-        '.json'
+        '.json',
+        '.yml'
     ]
 )
 def test_failed_line_meta(tmp_path, ext):
     tmp_path = str(tmp_path)
     repo_path = os.path.join(tmp_path, 'repo')
-    repo = ModelRepo(repo_path)
-    repo.add_line('0', DummyModel, meta_fmt=ext)
+    repo = ModelRepo(repo_path, meta_fmt=ext)
+    repo.add_line('0', DummyModel)
 
     model = DummyModel()
 
@@ -302,14 +307,15 @@ def test_failed_line_meta(tmp_path, ext):
 
 @pytest.mark.parametrize(
     'ext', [
-        '.json'
+        '.json',
+        '.yml'
     ]
 )
 def test_failed_model_meta(tmp_path, ext):
     tmp_path = str(tmp_path)
     repo_path = os.path.join(tmp_path, 'repo')
-    repo = ModelRepo(repo_path)
-    repo.add_line('0', DummyModel, meta_fmt=ext)
+    repo = ModelRepo(repo_path, meta_fmt=ext)
+    repo.add_line('0', DummyModel)
 
     model = DummyModel()
 

--- a/cascade/tests/test_model_repo.py
+++ b/cascade/tests/test_model_repo.py
@@ -43,10 +43,16 @@ def test_save_load(tmp_path, dummy_model):
     model = repo['0'][0]
 
 
-def test_overwrite(tmp_path):
+@pytest.mark.parametrize(
+    'ext', [
+        '.json',
+        '.yml'
+    ]
+)
+def test_overwrite(tmp_path, ext):
     tmp_path = str(tmp_path)
     # If no overwrite repo will have 4 models
-    repo = ModelRepo(tmp_path, overwrite=True)
+    repo = ModelRepo(tmp_path, overwrite=True, meta_fmt=ext)
     repo.add_line('vgg16', DummyModel)
     repo.add_line('resnet', DummyModel)
 
@@ -66,9 +72,15 @@ def test_add_line(tmp_path):
         repo.add_line(DummyModel, 'vgg16')  # wrong argument order
 
 
-def test_reusage(tmp_path):
+@pytest.mark.parametrize(
+    'ext', [
+        '.json',
+        '.yml'
+    ]
+)
+def test_reusage(tmp_path, ext):
     tmp_path = str(tmp_path)
-    repo = ModelRepo(tmp_path)
+    repo = ModelRepo(tmp_path, meta_fmt=ext)
     repo.add_line('vgg16', DummyModel)
 
     model = DummyModel()
@@ -76,14 +88,20 @@ def test_reusage(tmp_path):
 
     # some time...
 
-    repo = ModelRepo(tmp_path)
+    repo = ModelRepo(tmp_path, meta_fmt=ext)
     repo.add_line('vgg16', DummyModel)
     assert(len(repo['vgg16']) == 1)
 
 
-def test_reusage_init_alias(tmp_path):
+@pytest.mark.parametrize(
+    'ext', [
+        '.json',
+        '.yml'
+    ]
+)
+def test_reusage_init_alias(tmp_path, ext):
     tmp_path = str(tmp_path)
-    repo = ModelRepo(tmp_path)
+    repo = ModelRepo(tmp_path, meta_fmt=ext)
 
     repo.add_line('vgg16', DummyModel)
 
@@ -95,20 +113,26 @@ def test_reusage_init_alias(tmp_path):
     repo = ModelRepo(tmp_path, lines=[dict(
                             name='vgg16',
                             model_cls=DummyModel
-                        )])
+                        )], meta_fmt=ext)
     assert(len(repo['vgg16']) == 1)
 
 
-def test_meta(tmp_path):
+@pytest.mark.parametrize(
+    'ext', [
+        '.json',
+        '.yml'
+    ]
+)
+def test_meta(tmp_path, ext):
     tmp_path = str(tmp_path)
-    repo = ModelRepo(tmp_path)
+    repo = ModelRepo(tmp_path, meta_fmt=ext)
     repo.add_line('00000', DummyModel)
     repo.add_line('00001', DummyModel)
 
     meta = repo.get_meta()
     assert(meta[0]['len'] == 2)
 
-    repo = ModelRepo(tmp_path)
+    repo = ModelRepo(tmp_path, meta_fmt=ext)
     repo.add_line('00002', DummyModel)
 
     meta = repo.get_meta()
@@ -160,8 +184,8 @@ def test_add(tmp_path):
 def test_missing_repo_meta(tmp_path, ext):
     tmp_path = str(tmp_path)
     repo_path = os.path.join(tmp_path, 'repo')
-    repo = ModelRepo(repo_path)
-    repo.add_line('0', DummyModel, meta_fmt=ext)
+    repo = ModelRepo(repo_path, meta_fmt=ext)
+    repo.add_line('0', DummyModel)
 
     model = DummyModel()
 

--- a/cascade/tests/test_model_repo.py
+++ b/cascade/tests/test_model_repo.py
@@ -32,6 +32,17 @@ def test_repo(tmp_path):
     assert(2 == len(repo))
 
 
+def test_save_load(tmp_path, dummy_model):
+    tmp_path = str(tmp_path)
+    repo = ModelRepo(tmp_path)
+    repo.add_line('0', DummyModel)
+    repo['0'].save(dummy_model)
+
+    repo = ModelRepo(tmp_path, lines=[
+        dict(name='0', model_cls=DummyModel)])
+    model = repo['0'][0]
+
+
 def test_overwrite(tmp_path):
     tmp_path = str(tmp_path)
     # If no overwrite repo will have 4 models

--- a/cascade/tests/test_model_repo.py
+++ b/cascade/tests/test_model_repo.py
@@ -150,3 +150,75 @@ def test_add(tmp_path):
     for name, length in zip(line_names, line_lens):
         line = repo[name]
         assert len(line) == length
+
+
+@pytest.mark.parametrize(
+    'ext', [
+        '.json'
+    ]
+)
+def test_missing_repo_meta(tmp_path, ext):
+    tmp_path = str(tmp_path)
+    repo_path = os.path.join(tmp_path, 'repo')
+    repo = ModelRepo(repo_path)
+    repo.add_line('0', DummyModel, meta_fmt=ext)
+
+    model = DummyModel()
+
+    repo['0'].save(model)
+
+    # simulate missing meta
+    meta_path = os.path.join(repo_path, 'meta' + ext)
+    os.remove(meta_path)
+
+    repo = ModelRepo(repo_path, lines=[
+        dict(name='0', model_cls=DummyModel, meta_fmt=ext)])
+    model = repo['0'][0]
+
+
+@pytest.mark.parametrize(
+    'ext', [
+        '.json'
+    ]
+)
+def test_missing_line_meta(tmp_path, ext):
+    tmp_path = str(tmp_path)
+    repo_path = os.path.join(tmp_path, 'repo')
+    repo = ModelRepo(repo_path)
+    repo.add_line('0', DummyModel, meta_fmt=ext)
+
+    model = DummyModel()
+
+    repo['0'].save(model)
+
+    # simulate missing meta
+    meta_path = os.path.join(repo_path, '0', 'meta' + ext)
+    os.remove(meta_path)
+
+    repo = ModelRepo(repo_path, lines=[
+        dict(name='0', model_cls=DummyModel, meta_fmt=ext)])
+    model = repo['0'][0]
+
+
+@pytest.mark.parametrize(
+    'ext', [
+        '.json'
+    ]
+)
+def test_missing_model_meta(tmp_path, ext):
+    tmp_path = str(tmp_path)
+    repo_path = os.path.join(tmp_path, 'repo')
+    repo = ModelRepo(repo_path)
+    repo.add_line('0', DummyModel, meta_fmt=ext)
+
+    model = DummyModel()
+
+    repo['0'].save(model)
+
+    # simulate missing meta
+    meta_path = os.path.join(repo_path, '0', '00000', 'meta' + ext)
+    os.remove(meta_path)
+
+    repo = ModelRepo(repo_path, lines=[
+        dict(name='0', model_cls=DummyModel, meta_fmt=ext)])
+    model = repo['0'][0]


### PR DESCRIPTION
Important update of ModelRepo's reliability:
- Make more informative error messages in MetaHandlers
- Make MetaViewer lazy loaded, which should speed up large repos
- Meta file's format can be chosen from ModelLine and ModelRepo
- New tests are added
- ModelRepos now are more reliable in case of missing or broken meta files