### PR TITLE
Robust meta handling

### DIFF
--- a/cascade/meta/history_viewer.py
+++ b/cascade/meta/history_viewer.py
@@ -68,17 +68,22 @@ class HistoryViewer:
                 Consider updating your repo's meta by opening it with ModelRepo constructor in new version or manually.
                 In the following versions it will be deprecated.''', FutureWarning)
 
-            for i in range(len(line.model_names))[:self._last_models]:
+            for i in range(len(line))[:self._last_models]:
                 new_meta = {'line': line.root, 'num': i}
-                new_meta.update(flatten(view[i][-1]))
+                try:
+                    meta = view[i][-1]
+                except IndexError:
+                    meta = {}
+
+                new_meta.update(flatten(meta))
                 metas.append(new_meta)
 
                 params = {
                     'line': line.root,
                 }
-                if 'params' in view[i][-1]:
-                    if len(view[i][-1]['params']) > 0:
-                        params.update(flatten({'params': view[i][-1]['params']}))
+                if 'params' in meta:
+                    if len(meta['params']) > 0:
+                        params.update(flatten({'params': meta['params']}))
                 self._params.append(params)
 
         self._table = pd.DataFrame(metas)
@@ -178,8 +183,8 @@ class HistoryViewer:
 
         # Create human-readable ticks
         now = pendulum.now(tz='UTC')
-        time_text = [pendulum.parse(table['saved_at'].iloc[i]) for i in range(len(time))]
-        time_text = [t.diff_for_humans(now) for t in time_text]
+        time_text = table['saved_at']\
+            .apply(lambda t: t if t == '' else pendulum.parse(t).diff_for_humans(now))
 
         fig.update_layout(
             hovermode='x',

--- a/cascade/meta/meta_viewer.py
+++ b/cascade/meta/meta_viewer.py
@@ -23,7 +23,7 @@ class MetaViewer:
     """
     The class to read and write meta data.
     """
-    def __init__(self, root, filt=None, meta_fmt='.json') -> None:
+    def __init__(self, root, filt=None) -> None:
         """
         Parameters
         ----------
@@ -41,16 +41,15 @@ class MetaViewer:
         """
         if not os.path.exists(root):
             raise FileNotFoundError(root)
-        assert meta_fmt in supported_meta_formats, f'Only {supported_meta_formats} are supported formats'
 
         self._root = root
         self._filt = filt
-        self._meta_fmt = meta_fmt
         self._mh = MetaHandler()
 
         self.names = []
         for root, _, files in os.walk(self._root):
-            self.names += [os.path.join(root, name) for name in files if os.path.splitext(name)[-1] == self._meta_fmt]
+            self.names += [os.path.join(root, name)
+                           for name in files if os.path.splitext(name)[-1] in supported_meta_formats]
         self.names = sorted(self.names)
 
         if filt is not None:
@@ -72,7 +71,6 @@ class MetaViewer:
         """
         Dumps obj to path
         """
-        # self.metas.append(obj)
         self._mh.write(path, obj)
 
     def read(self, path) -> List[Dict]:

--- a/cascade/models/model_line.py
+++ b/cascade/models/model_line.py
@@ -61,11 +61,6 @@ class ModelLine(Traceable):
                 [os.path.join(model_folder, 'model')
                     for model_folder in os.listdir(self.root)
                     if os.path.isdir(os.path.join(self.root, model_folder))])
-
-            if len(self.model_names) == 0:
-                warnings.warn('Model folders were not found by the line. It may be that '
-                              'you are using new version of cascade with old repos '
-                              'created before version 0.2.0')
         else:
             # No folder -> create
             os.mkdir(self.root)

--- a/cascade/tests/test_history_viewer.py
+++ b/cascade/tests/test_history_viewer.py
@@ -71,9 +71,12 @@ def test_many_lines(model_repo, dummy_model):
     ]
 )
 def test_missing_model_meta(model_repo, dummy_model, ext):
-    model_repo.add_line('test', model_cls=DummyModel)
+    model_repo.add_line('test', model_cls=DummyModel, meta_fmt=ext)
+    dummy_model.evaluate()
     model_repo['test'].save(dummy_model)
-    os.remove(os.path.join(model_repo.root, 'test', '00000', 'meta', ext))
+    model_repo['test'].save(dummy_model)
+
+    os.remove(os.path.join(model_repo.root, 'test', '00000', 'meta' + ext))
 
     hv = HistoryViewer(model_repo)
     hv.plot('acc')

--- a/cascade/tests/test_history_viewer.py
+++ b/cascade/tests/test_history_viewer.py
@@ -21,7 +21,7 @@ import pytest
 MODULE_PATH = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
 sys.path.append(os.path.dirname(MODULE_PATH))
 
-from cascade.tests.conftest import EmptyModel
+from cascade.tests.conftest import EmptyModel, DummyModel
 from cascade.meta import HistoryViewer
 
 
@@ -59,6 +59,21 @@ def test_many_lines(model_repo, dummy_model):
 
     model_repo['0'].save(model0)
     model_repo['1'].save(model1)
+
+    hv = HistoryViewer(model_repo)
+    hv.plot('acc')
+
+
+@pytest.mark.parametrize(
+    'ext', [
+        '.json',
+        '.yml'
+    ]
+)
+def test_missing_model_meta(model_repo, dummy_model, ext):
+    model_repo.add_line('test', model_cls=DummyModel)
+    model_repo['test'].save(dummy_model)
+    os.remove(os.path.join(model_repo.root, 'test', '00000', 'meta', ext))
 
     hv = HistoryViewer(model_repo)
     hv.plot('acc')


### PR DESCRIPTION
When opened HistoryViewer in the repo which had modles with missin meta files an error occured. Now this behavior is fixed, models with missing meta are skipped in HistoryViewer.