### PR TITLE
Improve repo performace

### DIFF
--- a/cascade/meta/history_viewer.py
+++ b/cascade/meta/history_viewer.py
@@ -54,6 +54,7 @@ class HistoryViewer:
     def _make_table(self):
         metas = []
         self._params = []
+        # TODO: refactor this
         for line in [*self._repo][::-1][:self._last_lines]:
             # Try to use viewer only on models using type key
             try:

--- a/cascade/meta/meta_viewer.py
+++ b/cascade/meta/meta_viewer.py
@@ -62,22 +62,10 @@ class MetaViewer:
         meta: List[Dict]
             object containing meta
         """
-        return self.read(self.names[index])
+        return self._mh.read(self.names[index])
 
     def __len__(self) -> int:
         return len(self.names)
-
-    def write(self, path, obj: List[Dict]) -> None:
-        """
-        Dumps obj to path
-        """
-        self._mh.write(path, obj)
-
-    def read(self, path) -> List[Dict]:
-        """
-        Loads object from path
-        """
-        return self._mh.read(path)
 
     def _filter(self, name):
         meta = self.read(name)

--- a/cascade/meta/meta_viewer.py
+++ b/cascade/meta/meta_viewer.py
@@ -15,8 +15,10 @@ limitations under the License.
 """
 
 import os
+import warnings
 from typing import List, Dict
-from ..base import MetaHandler, JSONEncoder, supported_meta_formats
+
+from ..base import MetaHandler, supported_meta_formats
 
 
 class MetaViewer:
@@ -62,10 +64,24 @@ class MetaViewer:
         meta: List[Dict]
             object containing meta
         """
-        return self._mh.read(self.names[index])
+        return self.read(self.names[index])
 
     def __len__(self) -> int:
         return len(self.names)
+
+    def write(self, path, obj: List[Dict]) -> None:
+        """
+        Dumps obj to path
+        """
+        warnings.warn('This method will be deprecated in future versions. Consider using MetaHandler instead.')
+        self._mh.write(path, obj)
+
+    def read(self, path) -> List[Dict]:
+        """
+        Loads object from path
+        """
+        warnings.warn('This method will be deprecated in future versions. Consider using MetaHandler instead.')
+        return self._mh.read(path)
 
     def _filter(self, name):
         meta = self.read(name)

--- a/cascade/meta/meta_viewer.py
+++ b/cascade/meta/meta_viewer.py
@@ -89,7 +89,3 @@ class MetaViewer:
             if self._filt[key] != meta[key]:
                 return False
         return True
-
-    @staticmethod
-    def obj_to_dict(obj):
-        return JSONEncoder().obj_to_dict(obj)

--- a/cascade/meta/meta_viewer.py
+++ b/cascade/meta/meta_viewer.py
@@ -21,7 +21,7 @@ from ..base import MetaHandler, JSONEncoder, supported_meta_formats
 
 class MetaViewer:
     """
-    The class to read and write meta data.
+    The class to view all meta data files in folder.
     """
     def __init__(self, root, filt=None) -> None:
         """

--- a/cascade/meta/meta_viewer.py
+++ b/cascade/meta/meta_viewer.py
@@ -64,7 +64,7 @@ class MetaViewer:
         meta: List[Dict]
             object containing meta
         """
-        return self.read(self.names[index])
+        return self._mh.read(self.names[index])
 
     def __len__(self) -> int:
         return len(self.names)
@@ -84,7 +84,7 @@ class MetaViewer:
         return self._mh.read(path)
 
     def _filter(self, name):
-        meta = self.read(name)
+        meta = self._mh.read(name)
         meta = meta[-1]  # Takes last meta
         for key in self._filt:
             if key not in meta:

--- a/cascade/models/trainer.py
+++ b/cascade/models/trainer.py
@@ -100,6 +100,8 @@ class BasicTrainer(Trainer):
                 If None - the strategy is 'save only meta'.
         """
 
+        # TODO: check if eval_strategy specified that test_data provided also
+
         if train_kwargs is None:
             train_kwargs = {}
         if test_kwargs is None:

--- a/cascade/tests/test_meta_viewer.py
+++ b/cascade/tests/test_meta_viewer.py
@@ -21,6 +21,7 @@ import json
 MODULE_PATH = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
 sys.path.append(os.path.dirname(MODULE_PATH))
 
+from cascade.base import MetaHandler
 from cascade.meta import MetaViewer
 from cascade.models import ModelRepo
 from cascade.tests import DummyModel
@@ -34,9 +35,9 @@ def test(tmp_path):
     with open(os.path.join(tmp_path, 'test0.json'), 'w') as f:
         json.dump({'name': 'test0'}, f)
 
-    # Write also using mev
-    mev = MetaViewer(tmp_path)
-    mev.write(os.path.join(tmp_path, 'model', 'test1.json'), {'name': 'test1'})
+    # Write using mh
+    mh = MetaHandler()
+    mh.write(os.path.join(tmp_path, 'model', 'test1.json'), {'name': 'test1'})
 
     mev = MetaViewer(tmp_path)
 


### PR DESCRIPTION
This replaces MetaViewer in repo with MetaHandler, which accelerates repo's loading more than twice. It will considerably affect only repos with many lines and models, when loading time is already noticeable.

The second change is that MetaHandler methods read and write will be deprecated in future versions.