### PR TITLE
Patch Concatenator's meta

### DIFF
--- a/cascade/data/concatenator.py
+++ b/cascade/data/concatenator.py
@@ -67,7 +67,5 @@ class Concatenator(Dataset):
         Concatenator calls `get_meta()` of all its datasets
         """
         meta = super().get_meta()
-        meta[0]['data'] = {}
-        for ds in self._datasets:
-            meta[0]['data'][repr(ds)] = ds.get_meta()
+        meta[0]['data'] = [ds.get_meta() for ds in self._datasets]
         return meta

--- a/cascade/tests/test_concatenator.py
+++ b/cascade/tests/test_concatenator.py
@@ -31,6 +31,7 @@ def test_meta():
 
     c = Concatenator([n1, n2], meta_prefix={'num': 1})
     assert c.get_meta()[0]['num'] == 1
+    assert len(c.get_meta()[0]['data']) == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The problem with Concatenator's meta - if two of concatenated datasets are of the same type it merges it into one, hiding another. This is due to the facts that meta was dictionary - now it is a list.