### PR TITLE
Version assigner update

### DIFF
--- a/cascade/data/version_assigner.py
+++ b/cascade/data/version_assigner.py
@@ -50,6 +50,14 @@ class VersionAssigner(Modifier):
     something random or run-dependent like for example memory
     address of an object or time of creation, then the version will
     bump on every run.
+
+    Important
+    ---------
+    In current implementation counts only highest-level pipeline changes.
+    For example if final part of a pipeline is Concatenator will only
+    count it and not the structure of a pipelines before.
+    It is only applied to the major version changes and may be fixed in
+    following versions.
     """
     def __init__(self, dataset: Dataset, path: str, *args, **kwargs) -> None:
         """
@@ -64,38 +72,57 @@ class VersionAssigner(Modifier):
         super().__init__(dataset, *args, **kwargs)
         self._mh = MetaHandler()
         self._assign_path(path)   
-
         self._versions = {}
+
+        # get meta for info about pipeline
         meta = self._dataset.get_meta()
 
+        # TODO: extract all names
+        # use whole meta and pipeline which is only first-level names
         meta_str = str(meta)
         pipeline = ' '.join([m['name'] for m in meta])
 
+        # identify pipeline
         meta_hash = md5(str.encode(meta_str, 'utf-8')).hexdigest()
         pipe_hash = md5(str.encode(pipeline, 'utf-8')).hexdigest()
+
         if os.path.exists(self._root):
             self._versions = self._mh.read(self._root)    
 
             if pipe_hash in self._versions:
                 if meta_hash in self._versions[pipe_hash]:
-                    self.version = self._versions[pipe_hash][meta_hash]
+                    self.version = self._versions[pipe_hash][meta_hash]['version']
                 else:
                     last_ver = self._get_last_version_from_pipe(pipe_hash)
                     major, minor = self._split_ver(last_ver)
                     minor += 1
                     self.version = self._join_ver(major, minor)
-                    self._versions[pipe_hash][meta_hash] = self.version
+                    self._versions[pipe_hash][meta_hash] = {
+                        'version': self.version,
+                        'meta': meta,
+                        'pipeline': pipeline
+                    }
             else:
                 last_ver = self._get_last_version()
                 major, minor = self._split_ver(last_ver)
                 major += 1
                 self.version = self._join_ver(major, minor)
-                self._versions[pipe_hash] = {meta_hash: self.version}
+                self._versions[pipe_hash] = {}
+                self._versions[pipe_hash][meta_hash] = {
+                    'version': self.version,
+                    'meta': meta,
+                    'pipeline': pipeline
+                }
 
             self._mh.write(self._root, self._versions)
         else:
             self.version = '0.0'
-            self._versions[pipe_hash] = {meta_hash: self.version}
+            self._versions[pipe_hash] = {}
+            self._versions[pipe_hash][meta_hash] = {
+                'version': self.version,
+                'meta': meta,
+                'pipeline': pipeline
+            }
             self._mh.write(self._root, self._versions)
 
     def _assign_path(self, path):
@@ -114,14 +141,14 @@ class VersionAssigner(Modifier):
         return f'{major}.{minor}'
 
     def _get_last_version_from_pipe(self, pipe_hash):
-        versions = self._versions[pipe_hash].values()
+        versions = [item['version'] for item in self._versions[pipe_hash].values()]
         versions = sorted(versions)
         return versions[-1]
 
     def _get_last_version(self):
         versions_flat = []
         for pipe_hash in self._versions:
-            versions_flat += self._versions[pipe_hash].values()
+            versions_flat += [item['version'] for item in self._versions[pipe_hash].values()]
         versions = sorted(versions_flat)
         return versions[-1]
 

--- a/cascade/data/version_assigner.py
+++ b/cascade/data/version_assigner.py
@@ -59,7 +59,7 @@ class VersionAssigner(Modifier):
     It is only applied to the major version changes and may be fixed in
     following versions.
     """
-    def __init__(self, dataset: Dataset, path: str, *args, **kwargs) -> None:
+    def __init__(self, dataset: Dataset, path: str, verbose=False, *args, **kwargs) -> None:
         """
         Parameters
         ----------
@@ -124,6 +124,9 @@ class VersionAssigner(Modifier):
                 'pipeline': pipeline
             }
             self._mh.write(self._root, self._versions)
+        
+        if verbose:
+            print('Dataset version:', self.version)
 
     def _assign_path(self, path):
         _, ext = os.path.splitext(path)


### PR DESCRIPTION
Version assigner now stores whole pipeline meta in version log for user to be able to track which pipeline produced which version, which can help to go back to exact previous version. 
Optional verbosity is added.