### PR TITLE
Optional plotly

### DIFF
--- a/cascade/meta/history_viewer.py
+++ b/cascade/meta/history_viewer.py
@@ -20,9 +20,6 @@ import pendulum
 import pandas as pd
 from flatten_json import flatten
 from deepdiff import DeepDiff
-import plotly
-from plotly import express as px
-from plotly import graph_objects as go
 
 from ..models import ModelRepo
 from . import MetaViewer
@@ -123,6 +120,16 @@ class HistoryViewer:
         show: bool, optional
             Whether to return and show or just return figure
         """
+        try:
+            import plotly
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError('''
+                    Cannot import plotly. It is conditional
+                    dependency you can install it
+                    using the instructions from plotly official documentation''')
+        else:
+            from plotly import express as px
+            from plotly import graph_objects as go
 
         # After flatten 'metrics_' will be added to the metric name
         if not metric.startswith('metrics_'):

--- a/cascade/meta/metric_viewer.py
+++ b/cascade/meta/metric_viewer.py
@@ -19,7 +19,6 @@ from typing import Union, List, Any, NoReturn
 
 import pendulum
 from flatten_json import flatten
-from plotly import graph_objects as go
 import pandas as pd
 
 from . import MetaViewer
@@ -103,6 +102,17 @@ class MetricViewer:
         """
         Uses plotly to graphically show table with metrics and parameters.
         """
+
+        try:
+            import plotly
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError('''
+                        Cannot import plotly. It is conditional
+                        dependency you can install it
+                        using the instructions from plotly official documentation''')
+        else:
+            from plotly import graph_objects as go
+
         data = pd.DataFrame(map(flatten, self.table.to_dict('records')))
         fig = go.Figure(data=[
             go.Table(

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ numpy>=1.18.5
 pandas>=1.4.0
 deepdiff>=5.8.0
 pendulum>=2.1.2
-plotly>=5.7.0
 flatten_json>=0.1.13
 pyyaml>=5.4.1
+plotly>=5.7.0
+dash

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setuptools.setup(
         'pandas>=1.4.0',
         'deepdiff>=5.8.0',
         'pendulum>=2.1.2',
-        'plotly>=5.7.0',
         'flatten_json>=0.1.13',
         'pyyaml>=5.4.1'
     ]


### PR DESCRIPTION
Make plotly optional dependency. While plots are useful, they are not essential part of the lib and may be rarely used. All plotly-related functionality is unchanged