### PR TITLE
Add .yaml as format that also supported since it is another name of YAML

### DIFF
--- a/cascade/base/meta_handler.py
+++ b/cascade/base/meta_handler.py
@@ -25,7 +25,7 @@ import numpy as np
 
 from . import Meta
 
-supported_meta_formats = ('.json', '.yml')
+supported_meta_formats = ('.json', '.yml', '.yaml')
 
 
 class CustomEncoder(JSONEncoder):
@@ -156,7 +156,7 @@ class MetaHandler:
     """
     Encapsulates the logic of reading and writing metadata to disk.
 
-    Supported read-write formats are `json` and `yml`. Other formats
+    Supported read-write formats are `.json` and `.yml` or `.yaml`. Other formats
     are supported as read-only. For example one can read meta from txt or md file.
 
     Examples
@@ -215,7 +215,7 @@ class MetaHandler:
         ext = os.path.splitext(path)[-1]
         if ext == '.json':
             return JSONHandler()
-        elif ext == '.yml':
+        elif ext in ('.yml', '.yaml'):
             return YAMLHandler()
         else:
             return TextHandler()

--- a/cascade/meta/meta_validator.py
+++ b/cascade/meta/meta_validator.py
@@ -70,7 +70,7 @@ class MetaValidator(Validator):
     """
     def __init__(self, dataset: SizedDataset[T],
                  root: Union[str, None] = None,
-                 meta_fmt: Literal['.json', '.yml'] = '.json') -> None:
+                 meta_fmt: Literal['.json', '.yml', '.yaml'] = '.json') -> None:
         """
         Parameters
         ----------

--- a/cascade/models/model_line.py
+++ b/cascade/models/model_line.py
@@ -32,7 +32,7 @@ class ModelLine(Traceable):
     but different epochs or using different data.
     """
     def __init__(self, folder: str, model_cls: Type = Model,
-                 meta_fmt: Literal['.json', '.yml'] ='.json', **kwargs: Any) -> None:
+                 meta_fmt: Literal['.json', '.yml', '.yaml'] = '.json', **kwargs: Any) -> None:
         """
         All models in line should be instances of the same class.
 

--- a/cascade/models/model_repo.py
+++ b/cascade/models/model_repo.py
@@ -77,7 +77,7 @@ class ModelRepo(Repo):
         folder: str,
         lines: Union[Iterable[ModelLine], None] = None,
         overwrite: bool = False,
-        meta_fmt: Literal['.json', '.yml'] = '.json',
+        meta_fmt: Literal['.json', '.yml', '.yaml'] = '.json',
         model_cls: Type = Model, **kwargs: Any) -> None:
         """
         Parameters
@@ -92,7 +92,7 @@ class ModelRepo(Repo):
             in that place
         meta_fmt: str
             extension of repo's metadata files and that will be assigned to the lines by default
-            `.json` and `.yml` are supported
+            `.json` and `.yml` or `.yaml` are supported
         model_cls:
             Default class for any ModelLine in repo
         See also

--- a/cascade/tests/conftest.py
+++ b/cascade/tests/conftest.py
@@ -161,7 +161,8 @@ def empty_model():
     {
         'model_cls': DummyModel,
         'meta_fmt': '.yml'
-    }])
+    }
+])
 def model_line(request, tmp_path):
     line = ModelLine(str(tmp_path), **request.param)
     return line

--- a/cascade/tests/test_meta_handler.py
+++ b/cascade/tests/test_meta_handler.py
@@ -29,7 +29,8 @@ from cascade.base import MetaHandler
 @pytest.mark.parametrize(
     'ext', [
         '.json',
-        '.yml'
+        '.yml',
+        '.yaml'
     ]
 )
 def test(tmp_path, ext):
@@ -52,7 +53,8 @@ def test(tmp_path, ext):
 @pytest.mark.parametrize(
     'ext', [
         '.json',
-        '.yml'
+        '.yml',
+        '.yaml'
     ]
 )
 def test_overwrite(tmp_path, ext):
@@ -96,6 +98,7 @@ def test_text(tmp_path, ext):
     'ext', [
         '.json',
         '.yml',
+        '.yaml',
         '.txt',
         '.md'
     ]
@@ -112,7 +115,8 @@ def test_not_exist(ext):
 @pytest.mark.parametrize(
     'ext', [
         '.json',
-        '.yml'
+        '.yml',
+        '.yaml'
     ]
 )
 def test_read_fail(tmp_path, ext):
@@ -133,7 +137,8 @@ def test_read_fail(tmp_path, ext):
 @pytest.mark.parametrize(
     'ext', [
         '.json',
-        '.yml'
+        '.yml',
+        '.yaml'
     ]
 )
 def test_empty_file(tmp_path, ext):

--- a/cascade/utils/tests/test_sk_model.py
+++ b/cascade/utils/tests/test_sk_model.py
@@ -30,9 +30,15 @@ import cascade as csd
 from cascade import utils as csu
 
 
-def test_hash_check(tmp_path):
+@pytest.mark.parametrize(
+    'ext', [
+        '.json',
+        '.yml'
+    ]
+)
+def test_hash_check(tmp_path, ext):
     tmp_path = str(tmp_path)
-    repo = csd.models.ModelRepo(tmp_path, overwrite=True, meta_fmt='.yml')
+    repo = csd.models.ModelRepo(tmp_path, overwrite=True, meta_fmt=ext)
 
     tree = csu.SkModel(blocks=[
         DecisionTreeClassifier()


### PR DESCRIPTION
Add .yaml as also supported meta format since it is just a variation for YAML files to have not only .yml but also .yaml extension.