### PR TITLE
Meta typing

### DIFF
--- a/cascade/base/__init__.py
+++ b/cascade/base/__init__.py
@@ -17,9 +17,19 @@ limitations under the License.
 from typing import Union, List, Dict, Any
 
 """
-This type is used when get_meta is called on any Traceable
+Single Meta of basic object is just a dict, however Cascade supports
+pipelines with lists of meta.
+
+Do not use Meta when returning from `get_meta` methods! Use PipeMeta instead.
+Meta type alias is designed for better readability and to explicitly state when the
+variable is meta.
 """
-Meta = List[Dict[Any, Any]]
+Meta = Dict[Any, Any]
+
+"""
+This type is used when `get_meta` is called on any Traceable
+"""
+PipeMeta = List[Meta]
 
 """
 This type described what we can get when reading previously written to meta object

--- a/cascade/base/__init__.py
+++ b/cascade/base/__init__.py
@@ -14,10 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import List, Dict, Any
+from typing import Union, List, Dict, Any
 
+"""
+This type is used when get_meta is called on any Traceable
+"""
 Meta = List[Dict[Any, Any]]
 
+"""
+This type described what we can get when reading previously written to meta object
+"""
+MetaFromFile = Union[List[Any], Dict[Any, Any]]
+
+
 from .meta_handler import MetaHandler, supported_meta_formats
-from .traceable import Traceable, Meta
+from .traceable import Traceable
 from .meta_handler import CustomEncoder as JSONEncoder

--- a/cascade/base/meta_handler.py
+++ b/cascade/base/meta_handler.py
@@ -17,7 +17,7 @@ limitations under the License.
 import os
 import json
 import datetime
-from typing import NoReturn, Union, List, Dict, Any
+from typing import NoReturn, Union, Dict, Any
 from json import JSONEncoder
 
 import yaml
@@ -97,7 +97,7 @@ class JSONHandler(BaseHandler):
                 self._raise_io_error(path, e)
             return meta
 
-    def write(self, path: str, obj: List[Dict], overwrite: bool = True) -> None:
+    def write(self, path: str, obj: Any, overwrite: bool = True) -> None:
         if not overwrite and os.path.exists(path):
             return
 

--- a/cascade/base/meta_handler.py
+++ b/cascade/base/meta_handler.py
@@ -23,7 +23,7 @@ from json import JSONEncoder
 import yaml
 import numpy as np
 
-from . import Meta
+from . import MetaFromFile
 
 supported_meta_formats = ('.json', '.yml', '.yaml')
 
@@ -66,7 +66,7 @@ class CustomEncoder(JSONEncoder):
 
 
 class BaseHandler:
-    def read(self, path: str) -> Union[List[Any], Dict[Any, Any]]:
+    def read(self, path: str) -> MetaFromFile:
         raise NotImplementedError()
 
     def write(self, path: str, obj: Any, overwrite: bool = True) -> None:
@@ -83,7 +83,7 @@ class BaseHandler:
 
 
 class JSONHandler(BaseHandler):
-    def read(self, path: str) -> Union[List[Any], Dict[Any, Any]]:
+    def read(self, path: str) -> MetaFromFile:
         _, ext = os.path.splitext(path)
         if ext == '':
             path += '.json'
@@ -106,7 +106,7 @@ class JSONHandler(BaseHandler):
 
 
 class YAMLHandler(BaseHandler):
-    def read(self, path: str) -> Union[List[Any], Dict[Any, Any]]:
+    def read(self, path: str) -> MetaFromFile:
         _, ext = os.path.splitext(path)
         if ext == '':
             path += '.yml'
@@ -168,7 +168,7 @@ class MetaHandler:
     >>> mh.write('meta.yml', {'hello': 'world'})
     >>> obj = mh.read('meta.yml')
     """
-    def read(self, path: str) -> Union[List[Any], Dict[Any, Any]]:
+    def read(self, path: str) -> MetaFromFile:
         """
         Reads object from path.
 
@@ -179,7 +179,7 @@ class MetaHandler:
 
         Returns
         -------
-            obj: Union[List[Any], Dict[Any, Any]]
+            obj: MetaFromFile
 
         Raises
         ------

--- a/cascade/base/traceable.py
+++ b/cascade/base/traceable.py
@@ -59,10 +59,13 @@ class Traceable:
         Returns
         -------
         meta: PipeMeta
-            A list where last element is this object's metadata.
+            A list where first element is this object's metadata.
+            All other elements represent the other stages of pipeline if present.
+
             Meta can be anything that is worth to document about
             the object and its properties.
-            Meta is list to allow the formation of pipelines.
+
+            Meta is a list (see PipeMeta type alias) to allow the formation of pipelines.
         """
         meta = {
             'name': repr(self)

--- a/cascade/base/traceable.py
+++ b/cascade/base/traceable.py
@@ -17,7 +17,7 @@ limitations under the License.
 
 import warnings
 from typing import Dict, Union, Any
-from . import Meta, MetaFromFile
+from . import PipeMeta, MetaFromFile
 
 
 class Traceable:
@@ -34,7 +34,7 @@ class Traceable:
         """
         Parameters
         ----------
-        meta_prefix: Union[Dict, str], optional
+        meta_prefix: Union[Dict[Any, Any], str], optional
             The dictionary that is used to update object's meta in `get_meta` call.
             Due to the call of update can overwrite default values.
             If str - prefix assumed to be path and loaded using MetaHandler.
@@ -54,11 +54,11 @@ class Traceable:
         from . import MetaHandler
         return MetaHandler().read(path)
 
-    def get_meta(self) -> Meta:
+    def get_meta(self) -> PipeMeta:
         """
         Returns
         -------
-        meta: List[Dict]
+        meta: PipeMeta
             A list where last element is this object's metadata.
             Meta can be anything that is worth to document about
             the object and its properties.

--- a/cascade/base/traceable.py
+++ b/cascade/base/traceable.py
@@ -16,9 +16,8 @@ limitations under the License.
 
 
 import warnings
-from typing import List, Dict, Union, Any
-
-from . import Meta
+from typing import Dict, Union, Any
+from . import Meta, MetaFromFile
 
 
 class Traceable:
@@ -29,7 +28,7 @@ class Traceable:
     def __init__(
         self,
         *args: Any,
-        meta_prefix: Union[Meta, str, None] = None,
+        meta_prefix: Union[Dict[Any, Any], str, None] = None,
         **kwargs: Any
     ) -> None:
         """
@@ -51,11 +50,11 @@ class Traceable:
         self._meta_prefix = meta_prefix
 
     @staticmethod
-    def _read_meta_from_file(path: str) -> Union[List[Any], Dict[Any, Any]]:
+    def _read_meta_from_file(path: str) -> MetaFromFile:
         from . import MetaHandler
         return MetaHandler().read(path)
 
-    def get_meta(self) -> List[Dict]:
+    def get_meta(self) -> Meta:
         """
         Returns
         -------
@@ -74,7 +73,7 @@ class Traceable:
             self._warn_no_prefix()
         return [meta]
 
-    def update_meta(self, obj: Union[Dict, str]) -> None:
+    def update_meta(self, obj: Union[Dict[Any, Any], str]) -> None:
         """
         Updates `_meta_prefix`, which then updates
         dataset's meta when `get_meta()` is called

--- a/cascade/data/apply_modifier.py
+++ b/cascade/data/apply_modifier.py
@@ -23,7 +23,7 @@ class ApplyModifier(Modifier):
     Modifier that maps a function to given dataset's items in a lazy way.
     """
     def __init__(self, dataset: Dataset[T], func: Callable[[T], Any],
-                 *args: List[Any], **kwargs: Dict[Any, Any]) -> None:
+                 *args: Any, **kwargs: Any) -> None:
         """
         Parameters
         ----------

--- a/cascade/data/composer.py
+++ b/cascade/data/composer.py
@@ -18,7 +18,7 @@ limitations under the License.
 from typing import List, Tuple, Dict, Any
 
 from . import SizedDataset
-from ..base import Meta
+from ..base import PipeMeta
 
 
 class Composer(SizedDataset):
@@ -62,7 +62,7 @@ class Composer(SizedDataset):
     def __len__(self) -> int:
         return self._len
 
-    def get_meta(self) -> Meta:
+    def get_meta(self) -> PipeMeta:
         """
         Composer calls `get_meta()` of all its datasets
         """

--- a/cascade/data/concatenator.py
+++ b/cascade/data/concatenator.py
@@ -18,7 +18,7 @@ from typing import List, Any
 
 import numpy as np
 from .dataset import SizedDataset, T
-from ..base import Meta
+from ..base import PipeMeta
 
 
 class Concatenator(SizedDataset):
@@ -71,7 +71,7 @@ class Concatenator(SizedDataset):
         rp = super().__repr__()
         return f'{rp} of\n' + '\n'.join(repr(ds) for ds in self._datasets)
 
-    def get_meta(self) -> Meta:
+    def get_meta(self) -> PipeMeta:
         """
         Concatenator calls `get_meta()` of all its datasets
         """

--- a/cascade/data/dataset.py
+++ b/cascade/data/dataset.py
@@ -12,7 +12,7 @@ limitations under the License.
 """
 
 from typing import Dict, Generic, Iterable, List, TypeVar, Any, Sized, Sequence
-from ..base import Traceable, Meta
+from ..base import Traceable, PipeMeta
 
 T = TypeVar('T')
 
@@ -37,7 +37,7 @@ class Dataset(Generic[T], Traceable):
         """
         raise NotImplementedError()
 
-    def get_meta(self) -> Meta:
+    def get_meta(self) -> PipeMeta:
         """
         Returns
         -------
@@ -98,7 +98,7 @@ class Iterator(Dataset):
         for item in self._data:
             yield item
 
-    def get_meta(self) -> Meta:
+    def get_meta(self) -> PipeMeta:
         meta = super().get_meta()
         meta[0]['obj_type'] = str(type(self._data))
         return meta
@@ -118,7 +118,7 @@ class Wrapper(SizedDataset):
     def __len__(self) -> int:
         return len(self._data)
 
-    def get_meta(self) -> Meta:
+    def get_meta(self) -> PipeMeta:
         meta = super().get_meta()
         meta[0]['len'] = len(self)
         meta[0]['obj_type'] = str(type(self._data))
@@ -139,6 +139,7 @@ class Modifier(SizedDataset):
     def __init__(self, dataset: SizedDataset[T], *args: Any, **kwargs: Any) -> None:
         """
         Constructs a Modifier. Makes no transformations in initialization.
+
         Parameters
         ----------
         dataset: Dataset
@@ -157,7 +158,7 @@ class Modifier(SizedDataset):
     def __len__(self) -> int:
         return len(self._dataset)
 
-    def get_meta(self) -> Meta:
+    def get_meta(self) -> PipeMeta:
         """
         Overrides base method enabling cascade-like calls to previous datasets.
         The metadata of a pipeline that consist of several modifiers can be easily

--- a/cascade/data/dataset.py
+++ b/cascade/data/dataset.py
@@ -41,7 +41,7 @@ class Dataset(Generic[T], Traceable):
         """
         Returns
         -------
-        meta: Meta
+        meta: PipeMeta
             A list where last element is this dataset's metadata.
             Meta can be anything that is worth to document about the dataset and its data.
             This is done in form of list to enable cascade-like calls in Modifiers and Samplers.

--- a/cascade/data/folder_dataset.py
+++ b/cascade/data/folder_dataset.py
@@ -18,7 +18,7 @@ import os
 
 from typing import Any
 from hashlib import md5
-from ..base import Meta
+from ..base import PipeMeta
 from .dataset import SizedDataset, T
 
 
@@ -48,7 +48,7 @@ class FolderDataset(SizedDataset):
     def __getitem__(self, item: int) -> T:
         raise NotImplementedError()
 
-    def get_meta(self) -> Meta:
+    def get_meta(self) -> PipeMeta:
         meta = super().get_meta()
         meta[0].update({
             'name': repr(self),

--- a/cascade/data/version_assigner.py
+++ b/cascade/data/version_assigner.py
@@ -16,9 +16,9 @@ limitations under the License.
 
 import os
 from hashlib import md5
-from typing import Dict, List, Any, Tuple
+from typing import Any, Tuple
 from . import Dataset, Modifier, T
-from ..base import MetaHandler, supported_meta_formats
+from ..base import MetaHandler, supported_meta_formats, Meta
 from ..meta import skeleton
 
 
@@ -172,7 +172,7 @@ class VersionAssigner(Modifier):
         versions = sorted(versions_flat)
         return versions[-1]
 
-    def get_meta(self) -> List[Dict]:
+    def get_meta(self) -> Meta:
         meta = super().get_meta()
         meta[0]['version'] = self.version
         return meta

--- a/cascade/data/version_assigner.py
+++ b/cascade/data/version_assigner.py
@@ -18,7 +18,7 @@ import os
 from hashlib import md5
 from typing import Any, Tuple
 from . import Dataset, Modifier, T
-from ..base import MetaHandler, supported_meta_formats, Meta
+from ..base import MetaHandler, supported_meta_formats, PipeMeta
 from ..meta import skeleton
 
 
@@ -172,7 +172,7 @@ class VersionAssigner(Modifier):
         versions = sorted(versions_flat)
         return versions[-1]
 
-    def get_meta(self) -> Meta:
+    def get_meta(self) -> PipeMeta:
         meta = super().get_meta()
         meta[0]['version'] = self.version
         return meta

--- a/cascade/meta/meta_validator.py
+++ b/cascade/meta/meta_validator.py
@@ -22,7 +22,7 @@ from deepdiff import DeepDiff
 
 from . import Validator, DataValidationException
 from ..data import SizedDataset, T
-from ..base import MetaHandler, supported_meta_formats, Meta, MetaFromFile
+from ..base import MetaHandler, supported_meta_formats, PipeMeta, MetaFromFile
 
 
 class MetaValidator(Validator):
@@ -106,14 +106,14 @@ class MetaValidator(Validator):
         else:
             self._save(meta, name)
 
-    def _save(self, meta: Meta, name: str) -> None:
+    def _save(self, meta: PipeMeta, name: str) -> None:
         self._mh.write(name, meta)
         print(f'Saved as {name}!')
 
     def _load(self, name: str) -> MetaFromFile:
         return self._mh.read(name)
 
-    def _check(self, query_meta: Meta) -> None:
+    def _check(self, query_meta: PipeMeta) -> None:
         diff = DeepDiff(self.base_meta, query_meta, verbose_level=2)
         if len(diff):
             print(diff.pretty())

--- a/cascade/meta/meta_validator.py
+++ b/cascade/meta/meta_validator.py
@@ -22,7 +22,7 @@ from deepdiff import DeepDiff
 
 from . import Validator, DataValidationException
 from ..data import SizedDataset, T
-from ..base import MetaHandler, supported_meta_formats, Meta
+from ..base import MetaHandler, supported_meta_formats, Meta, MetaFromFile
 
 
 class MetaValidator(Validator):
@@ -110,10 +110,10 @@ class MetaValidator(Validator):
         self._mh.write(name, meta)
         print(f'Saved as {name}!')
 
-    def _load(self, name: str) -> Meta:
+    def _load(self, name: str) -> MetaFromFile:
         return self._mh.read(name)
 
-    def _check(self, query_meta) -> None:
+    def _check(self, query_meta: Meta) -> None:
         diff = DeepDiff(self.base_meta, query_meta, verbose_level=2)
         if len(diff):
             print(diff.pretty())

--- a/cascade/meta/meta_viewer.py
+++ b/cascade/meta/meta_viewer.py
@@ -18,7 +18,7 @@ import os
 import warnings
 from typing import Dict, Union, Any
 
-from ..base import MetaHandler, supported_meta_formats, Meta, MetaFromFile
+from ..base import MetaHandler, supported_meta_formats, MetaFromFile
 
 
 class MetaViewer:

--- a/cascade/meta/meta_viewer.py
+++ b/cascade/meta/meta_viewer.py
@@ -18,14 +18,14 @@ import os
 import warnings
 from typing import Dict, Union, Any
 
-from ..base import MetaHandler, supported_meta_formats, Meta
+from ..base import MetaHandler, supported_meta_formats, Meta, MetaFromFile
 
 
 class MetaViewer:
     """
     The class to view all metadata in folders and subfolders.
     """
-    def __init__(self, root: str, filt: Union[Dict[str, Any], None] = None) -> None:
+    def __init__(self, root: str, filt: Union[Dict[Any, Any], None] = None) -> None:
         """
         Parameters
         ----------
@@ -56,19 +56,19 @@ class MetaViewer:
         if filt is not None:
             self.names = list(filter(self._filter, self.names))
 
-    def __getitem__(self, index: int) -> Meta:
+    def __getitem__(self, index: int) -> MetaFromFile:
         """
         Returns
         -------
-        meta: List[Dict]
-            Meta object
+        meta: MetaFromFile
+            Meta object that was read from file
         """
         return self._mh.read(self.names[index])
 
     def __len__(self) -> int:
         return len(self.names)
 
-    def write(self, path: str, obj: Meta) -> None:
+    def write(self, path: str, obj: Any) -> None:
         """
         Dumps obj to path
         """
@@ -76,7 +76,7 @@ class MetaViewer:
             Consider using MetaHandler instead.')
         self._mh.write(path, obj)
 
-    def read(self, path: str) -> Meta:
+    def read(self, path: str) -> MetaFromFile:
         """
         Loads object from path
         """

--- a/cascade/meta/utils.py
+++ b/cascade/meta/utils.py
@@ -25,7 +25,7 @@ default_keys = ['data', 'dataset']
 def skeleton(
     meta: Union[Meta, Dict[Any, Any]],
     keys: Union[List[str], None] = None
-) -> List[List[Dict[str, str]]]:
+) -> List[List[Dict[Any, Any]]]:
     """
     Parameters
     ----------
@@ -40,7 +40,7 @@ def skeleton(
 
     Returns
     -------
-    skeleton: List[List[Dict[str, str]]]
+    skeleton: List[List[Dict[Any, Any]]]
     """
 
     if keys is not None:

--- a/cascade/meta/utils.py
+++ b/cascade/meta/utils.py
@@ -16,20 +16,20 @@ limitations under the License.
 
 from typing import Union, List, Dict, Any
 
-from ..base import Meta
+from ..base import Meta, PipeMeta
 
 
 default_keys = ['data', 'dataset']
 
 
 def skeleton(
-    meta: Union[Meta, Dict[Any, Any]],
+    meta: Union[PipeMeta, Meta],
     keys: Union[List[str], None] = None
 ) -> List[List[Dict[Any, Any]]]:
     """
     Parameters
     ----------
-    meta: Union[Meta, Dict[Any, Any]]
+    meta: Union[PipeMeta, Meta]
         Meta of the pipeline
     keys: List[str], optional
         The set of keys in meta where to search for previous dataset's meta.

--- a/cascade/meta/utils.py
+++ b/cascade/meta/utils.py
@@ -24,14 +24,14 @@ default_keys = ['data', 'dataset']
 
 def skeleton(
     meta: Union[PipeMeta, Meta],
-    keys: Union[List[str], None] = None
+    keys: Union[List[Any], None] = None
 ) -> List[List[Dict[Any, Any]]]:
     """
     Parameters
     ----------
     meta: Union[PipeMeta, Meta]
         Meta of the pipeline
-    keys: List[str], optional
+    keys: List[Any], optional
         The set of keys in meta where to search for previous dataset's meta.
         For example Concatenator when get_meta() is called stores meta of its
         datasets in the field called 'data'.

--- a/cascade/models/basic_model.py
+++ b/cascade/models/basic_model.py
@@ -36,7 +36,7 @@ class BasicModel(Model):
     def save(self, filepath: str) -> None:
         raise NotImplementedError()
 
-    def predict(self, x: Any, *args: Any, **kwargs: Any):
+    def predict(self, x: Any, *args: Any, **kwargs: Any) -> Any:
         raise NotImplementedError()
 
     def evaluate(self, x: Any, y: Any,

--- a/cascade/models/model.py
+++ b/cascade/models/model.py
@@ -18,7 +18,7 @@ import warnings
 from typing import List, Dict, Any, Union
 import pendulum
 
-from ..base import Traceable, Meta
+from ..base import Traceable, PipeMeta
 
 
 class Model(Traceable):
@@ -27,7 +27,7 @@ class Model(Traceable):
     Used to provide unified interface to any model, store metadata including metrics.
     """
     def __init__(self, *args: Any,
-                 meta_prefix: Union[Meta, str, None] = None, **kwargs: Any) -> None:
+                 meta_prefix: Union[PipeMeta, str, None] = None, **kwargs: Any) -> None:
         """
         Should be called in any successor - initializes default meta needed.
         Arguments passed in it should be related to model's hyperparameters, architecture.
@@ -75,7 +75,7 @@ class Model(Traceable):
         """
         raise NotImplementedError()
 
-    def get_meta(self) -> Meta:
+    def get_meta(self) -> PipeMeta:
         # Successors may not call super().__init__
         # they may not have these default fields
 
@@ -121,6 +121,6 @@ class ModelModifier(Model):
         self._model = model
         super().__init__(*args, **kwargs)
 
-    def get_meta(self) -> Meta:
+    def get_meta(self) -> PipeMeta:
         prev_meta = self._model.get_meta()
         return super().get_meta() + prev_meta

--- a/cascade/models/model_line.py
+++ b/cascade/models/model_line.py
@@ -21,7 +21,7 @@ import pendulum
 import glob
 from hashlib import md5
 
-from ..base import Traceable, MetaHandler, supported_meta_formats, Meta
+from ..base import Traceable, MetaHandler, supported_meta_formats, PipeMeta
 from .model import Model
 
 
@@ -153,7 +153,7 @@ class ModelLine(Traceable):
     def __repr__(self) -> str:
         return f'ModelLine of {len(self)} models of {self._model_cls}'
 
-    def get_meta(self) -> Meta:
+    def get_meta(self) -> PipeMeta:
         meta = super().get_meta()
         meta[0].update({
             'root': self.root,

--- a/cascade/models/model_repo.py
+++ b/cascade/models/model_repo.py
@@ -21,7 +21,7 @@ import shutil
 import pendulum
 from deepdiff.diff import DeepDiff
 
-from ..base import Traceable, MetaHandler, JSONEncoder, supported_meta_formats, Meta
+from ..base import Traceable, MetaHandler, JSONEncoder, supported_meta_formats, PipeMeta
 from .model import Model
 from .model_line import ModelLine
 
@@ -234,7 +234,7 @@ class ModelRepo(Repo):
         except IOError as e:
             warnings.warn(f'File writing error ignored: {e}')
 
-    def get_meta(self) -> Meta:
+    def get_meta(self) -> PipeMeta:
         meta = super().get_meta()
         meta[0].update({
             'root': self._root,

--- a/cascade/utils/numpy_wrapper.py
+++ b/cascade/utils/numpy_wrapper.py
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Dict, List, Any
+from typing import Any
 import numpy as np
 from ..data import Wrapper
-from ..base import Meta
+from ..base import PipeMeta
 
 
 class NumpyWrapper(Wrapper):
@@ -28,7 +28,7 @@ class NumpyWrapper(Wrapper):
         self._path = path
         super().__init__(np.load(path), *args, **kwargs)
 
-    def get_meta(self) -> Meta:
+    def get_meta(self) -> PipeMeta:
         meta = super().get_meta()
         meta[0]['root'] = self._path
         return meta

--- a/cascade/utils/sk_model.py
+++ b/cascade/utils/sk_model.py
@@ -21,7 +21,7 @@ import pickle
 from typing import Any, Dict, List, Union, Any
 from sklearn.pipeline import Pipeline
 
-from ..base import MetaHandler, Meta
+from ..base import MetaHandler, PipeMeta
 from ..models import BasicModel
 
 
@@ -111,7 +111,7 @@ class SkModel(BasicModel):
         with open(f'{path}', 'wb') as f:
             pickle.dump(self._pipeline, f)
 
-    def get_meta(self) -> Meta:
+    def get_meta(self) -> PipeMeta:
         meta = super().get_meta()
         meta[0].update({
             'pipeline': repr(self._pipeline)

--- a/cascade/utils/table_dataset.py
+++ b/cascade/utils/table_dataset.py
@@ -20,7 +20,7 @@ from dask import dataframe as dd
 
 from ..meta import AggregateValidator, DataValidationException
 from ..data import Dataset, Modifier, Iterator, SequentialCacher
-from ..base import Meta
+from ..base import PipeMeta
 
 class TableDataset(Dataset):
     """
@@ -59,7 +59,7 @@ class TableDataset(Dataset):
         """
         return len(self._table)
 
-    def get_meta(self) -> Meta:
+    def get_meta(self) -> PipeMeta:
         meta = super().get_meta()
         meta[0].update({
             'name': repr(self),

--- a/cascade/utils/text_classification_dataset.py
+++ b/cascade/utils/text_classification_dataset.py
@@ -19,7 +19,7 @@ from typing import Any, Tuple
 
 import numpy as np
 from ..data import Dataset
-from ..base import Meta
+from ..base import PipeMeta
 
 
 class TextClassificationDataset(Dataset):
@@ -65,7 +65,7 @@ class TextClassificationDataset(Dataset):
         """
         return len(self._paths)
 
-    def get_meta(self) -> Meta:
+    def get_meta(self) -> PipeMeta:
         meta = super().get_meta()
         meta[0].update({
             'name': repr(self),

--- a/cascade/utils/time_series_dataset.py
+++ b/cascade/utils/time_series_dataset.py
@@ -21,7 +21,7 @@ from datetime import datetime
 import numpy as np
 import pandas as pd
 
-from ..base import Meta
+from ..base import PipeMeta
 from ..data import Dataset, Modifier
 
 
@@ -157,7 +157,7 @@ class TimeSeriesDataset(Dataset):
     def __len__(self) -> int:
         return len(self._num_idx)
 
-    def get_meta(self) -> Meta:
+    def get_meta(self) -> PipeMeta:
         meta = super().get_meta()
         meta[0].update(
             {
@@ -202,7 +202,7 @@ class Average(TimeSeriesDataset, Modifier):
         super().__init__(dataset, time=reg_time,
                          data=reg_data, *args, **kwargs)
 
-    def get_meta(self) -> Meta:
+    def get_meta(self) -> PipeMeta:
         meta = super().get_meta()
         meta[0].update(
             {
@@ -241,7 +241,7 @@ class Interpolate(TimeSeriesDataset, Modifier):
         self._method = method
         self._limit_direction = limit_direction
 
-    def get_meta(self) -> Meta:
+    def get_meta(self) -> PipeMeta:
         meta = super().get_meta()
         meta[0].update(
             {

--- a/cascade/utils/torch_model.py
+++ b/cascade/utils/torch_model.py
@@ -17,7 +17,7 @@ limitations under the License.
 from typing import Type, Any
 import torch
 from ..models import Model
-from ..base import Meta
+from ..base import PipeMeta
 
 
 class TorchModel(Model):
@@ -56,7 +56,7 @@ class TorchModel(Model):
         with open(path, 'rb') as f:
             self._model = torch.load(f)
 
-    def get_meta(self) -> Meta:
+    def get_meta(self) -> PipeMeta:
         meta = super().get_meta()
         meta[0]['module'] = repr(self._model)
         return meta

--- a/cascade/utils/weighed_sampler.py
+++ b/cascade/utils/weighed_sampler.py
@@ -21,7 +21,7 @@ import numpy as np
 from tqdm import trange
 
 from ..data import SizedDataset, Sampler
-from ..base import Meta
+from ..base import PipeMeta
 
 
 class WeighedSampler(Sampler):
@@ -92,7 +92,7 @@ class WeighedSampler(Sampler):
         idx = self._indices[index]
         return self._dataset[idx]
 
-    def get_meta(self) -> Meta:
+    def get_meta(self) -> PipeMeta:
         meta = super().get_meta()
         meta[0]['partitioning'] = self._partitioning
         return meta


### PR DESCRIPTION
Give Meta more rigorous typing scheme:
Then:
Meta is List[Dict[Any, Any]], which is used for writing and reading (with extensions)

Now:
Meta is Dict[Any, Any] and it describes singular meta
PipeMeta is List[Meta] and describes meta that we obtain from any Traceable
MetaFromFile is List[Any], Dict[Any, Any] describes the type that we can read from meta file - since we receiving from unbounded source, we are more liberal with type