### PR TITLE
Fix weighed sampler

### DIFF
--- a/cascade/utils/tests/conftest.py
+++ b/cascade/utils/tests/conftest.py
@@ -14,7 +14,7 @@ limitations under the License.
 import pytest
 import datetime
 from cascade import utils as cdu
-from cascade.data import Dataset
+from cascade.data import Dataset, Wrapper
 
 import pandas as pd
 
@@ -22,8 +22,13 @@ import pandas as pd
 @pytest.fixture(
     params=[
         cdu.TableDataset(t=pd.DataFrame([[1, 2, 3]])),
-        cdu.TableFilter(cdu.TableDataset(t=pd.DataFrame([[1, 2, 3]])), [False, True, False]),
-        cdu.TimeSeriesDataset(time=[datetime.datetime(2022, 12, 2)], data=[24])
+        cdu.TableFilter(cdu.TableDataset(t=pd.DataFrame([[1, 2, 3]])), [0, 1, 0]),
+        cdu.TimeSeriesDataset(time=[datetime.datetime(2022, 12, 2)], data=[24]),
+        cdu.OverSampler(Wrapper([(0, 0), (0, 0), (0, 1), (0, 0)])),
+        cdu.UnderSampler(Wrapper([(0, 0), (0, 0), (0, 1), (0, 0)])),
+        cdu.WeighedSampler(Wrapper([(0, 0), (0, 0), (0, 1), (0, 0)]), {0: 1}),
+        cdu.WeighedSampler(Wrapper([(0, 0), (0, 0), (0, 1), (0, 0)]), {0: 1, 1: 2}),
+        cdu.WeighedSampler(Wrapper([(0, 0), (0, 0), (0, 1), (0, 0)])),
     ]
 )
 def utils_dataset(request) -> Dataset:

--- a/cascade/utils/tests/conftest.py
+++ b/cascade/utils/tests/conftest.py
@@ -22,7 +22,7 @@ import pandas as pd
 @pytest.fixture(
     params=[
         cdu.TableDataset(t=pd.DataFrame([[1, 2, 3]])),
-        cdu.TableFilter(cdu.TableDataset(t=pd.DataFrame([[1, 2, 3]])), [0, 1, 0]),
+        cdu.TableFilter(cdu.TableDataset(t=pd.DataFrame([[1, 2, 3]])), [False, True, False]),
         cdu.TimeSeriesDataset(time=[datetime.datetime(2022, 12, 2)], data=[24])
     ]
 )

--- a/cascade/utils/weighed_sampler.py
+++ b/cascade/utils/weighed_sampler.py
@@ -60,6 +60,8 @@ class WeighedSampler(Sampler):
         """
         labels = np.asarray([dataset[i][1] for i in trange(len(dataset))])
         ulabels, counts = np.unique(labels, return_counts=True)
+        # Convert to lists to prevent serialization problems with metadata
+        ulabels, counts = ulabels.tolist(), counts.tolist()
 
         if partitioning is None:
             partitioning = {}


### PR DESCRIPTION
Fix the bug when metadata of `WeighedSampler` with partially initialized partitioning failed to save