### PR TITLE
Unify repos and lines

### DIFF
--- a/cascade/meta/history_viewer.py
+++ b/cascade/meta/history_viewer.py
@@ -66,11 +66,12 @@ class HistoryViewer(Server):
 
         for line_name in line_names:
             line = self._repo[line_name]
-            view = MetaViewer(line.root, filt={"type": "model"})
+            line_root = line.get_root()
+            view = MetaViewer(line_root, filt={"type": "model"})
 
             last_models = self._last_models if self._last_models is not None else 0
             for i in range(len(line))[-last_models:]:
-                new_meta = {"line": line.root, "model": i}
+                new_meta = {"line": line_root, "model": i}
                 try:
                     # TODO: to take only first is not good...
                     meta = view[i][0]
@@ -81,7 +82,7 @@ class HistoryViewer(Server):
                 metas.append(new_meta)
 
                 p = {
-                    "line": line.root,
+                    "line": line_root,
                 }
                 if "params" in meta:
                     if len(meta["params"]) > 0:

--- a/cascade/meta/history_viewer.py
+++ b/cascade/meta/history_viewer.py
@@ -21,7 +21,7 @@ import pandas as pd
 from flatten_json import flatten
 from deepdiff import DeepDiff
 
-from ..models import ModelRepo
+from ..models import ModelRepo, ModelLine, SingleLineRepo
 from . import Server, MetaViewer
 
 
@@ -34,7 +34,7 @@ class HistoryViewer(Server):
 
     def __init__(
         self,
-        repo: ModelRepo,
+        repo: Union[ModelRepo, ModelLine],
         last_lines: Union[int, None] = None,
         last_models: Union[int, None] = None,
     ) -> None:
@@ -48,6 +48,8 @@ class HistoryViewer(Server):
         last_models: int, optional
             For each line constraints the number of models back from the last one to view
         """
+        if isinstance(repo, ModelLine):
+            repo = SingleLineRepo(repo)
         self._repo = repo
         self._last_lines = last_lines
         self._last_models = last_models

--- a/cascade/meta/metric_viewer.py
+++ b/cascade/meta/metric_viewer.py
@@ -22,7 +22,7 @@ from flatten_json import flatten
 import pandas as pd
 
 from . import Server, MetaViewer
-from ..models import Model, ModelRepo
+from ..models import Model, ModelRepo, ModelLine, SingleLineRepo
 
 
 class MetricViewer:
@@ -32,7 +32,7 @@ class MetricViewer:
     As metrics it uses data from `metrics` field in models'
     meta and as parameters it uses `params` field.
     """
-    def __init__(self, repo: ModelRepo, scope: Union[int, str, slice, None] = None) -> None:
+    def __init__(self, repo: Union[ModelRepo, ModelLine], scope: Union[int, str, slice, None] = None) -> None:
         """
         Parameters
         ----------
@@ -41,6 +41,8 @@ class MetricViewer:
         scope: Union[int, str, slice]
             Index or a name of line to view. Can be set using `__getitem__`
         """
+        if isinstance(repo, ModelLine):
+            repo = SingleLineRepo(repo)
         self._repo = repo
         self._scope = scope
         self._metrics = []

--- a/cascade/meta/metric_viewer.py
+++ b/cascade/meta/metric_viewer.py
@@ -66,9 +66,9 @@ class MetricViewer:
 
         for name in selected_names:
             line = self._repo[name]
-            viewer_root = line.root
+            viewer_root = line.get_root()
 
-            view = MetaViewer(viewer_root, filt={'type': 'model'})
+            view = MetaViewer(viewer_root, filt={"type": "model"})
 
             for i in range(len(line.model_names)):
                 try:
@@ -76,23 +76,19 @@ class MetricViewer:
                 except IndexError:
                     meta = {}
 
-                metric = {
-                    'line': viewer_root,
-                    'num': i
-                }
+                metric = {"line": viewer_root, "num": i}
 
-                if 'created_at' in meta:
-                    metric['created_at'] = \
-                        pendulum.parse(meta['created_at'])
-                    if 'saved_at' in meta:
-                        metric['saved'] = \
-                            pendulum.parse(meta['saved_at']) \
-                            .diff_for_humans(metric['created_at'])
+                if "created_at" in meta:
+                    metric["created_at"] = pendulum.parse(meta["created_at"])
+                    if "saved_at" in meta:
+                        metric["saved"] = pendulum.parse(
+                            meta["saved_at"]
+                        ).diff_for_humans(metric["created_at"])
 
-                if 'metrics' in meta:
-                    metric.update(meta['metrics'])
-                if 'params' in meta:
-                    metric.update(meta['params'])
+                if "metrics" in meta:
+                    metric.update(meta["metrics"])
+                if "params" in meta:
+                    metric.update(meta["params"])
 
                 self._metrics.append(metric)
         self.table = pd.DataFrame(self._metrics)
@@ -108,24 +104,30 @@ class MetricViewer:
         try:
             import plotly
         except ModuleNotFoundError:
-            raise ModuleNotFoundError('''
+            raise ModuleNotFoundError(
+                """
                         Cannot import plotly. It is conditional
                         dependency you can install it
-                        using the instructions from plotly official documentation''')
+                        using the instructions from plotly official documentation"""
+            )
         else:
             from plotly import graph_objects as go
 
-        data = pd.DataFrame(map(flatten, self.table.to_dict('records')))
-        fig = go.Figure(data=[
-            go.Table(
-                header=dict(values=list(data.columns),
-                            fill_color='#f4c9c7',
-                            align='left'),
-                cells=dict(values=[data[col] for col in data.columns],
-                           fill_color='#bcced4',
-                           align='left')
-            )
-        ])
+        data = pd.DataFrame(map(flatten, self.table.to_dict("records")))
+        fig = go.Figure(
+            data=[
+                go.Table(
+                    header=dict(
+                        values=list(data.columns), fill_color="#f4c9c7", align="left"
+                    ),
+                    cells=dict(
+                        values=[data[col] for col in data.columns],
+                        fill_color="#bcced4",
+                        align="left",
+                    ),
+                )
+            ]
+        )
         if show:
             fig.show()
         return fig
@@ -147,25 +149,26 @@ class MetricViewer:
         TypeError if metric objects cannot be sorted. If only one model in repo, then
         returns it without error since no sorting involved.
         """
-        assert metric in self.table, f'{metric} is not in {self.table.columns}'
+        assert metric in self.table, f"{metric} is not in {self.table.columns}"
         t = self.table.loc[self.table[metric].notna()]
 
         try:
             t = t.sort_values(metric, ascending=maximize)
         except TypeError as e:
-            raise TypeError(f'Metric {metric} objects cannot be sorted') from e
+            raise TypeError(f"Metric {metric} objects cannot be sorted") from e
 
         best_row = t.iloc[-1]
-        name = os.path.split(best_row['line'])[-1]
-        num = best_row['num']
+        name = os.path.split(best_row["line"])[-1]
+        num = best_row["num"]
         return self._repo[name][num]
 
     def serve(
-            self,
-            page_size: int = 50,
-            include: Union[List[str], None] = None,
-            exclude: Union[List[str], None] = None,
-            **kwargs: Any) -> None:
+        self,
+        page_size: int = 50,
+        include: Union[List[str], None] = None,
+        exclude: Union[List[str], None] = None,
+        **kwargs: Any,
+    ) -> None:
         """
         Runs dash-based server with interactive table of metrics and parameters
 
@@ -181,15 +184,21 @@ class MetricViewer:
         **kwargs:
             Arguments of dash app. Can be ip or port for example
         """
-        server = MetricServer(self, page_size=page_size, include=include, exclude=exclude)
+        server = MetricServer(
+            self, page_size=page_size, include=include, exclude=exclude
+        )
         server.serve(**kwargs)
 
 
 class MetricServer(Server):
-    def __init__(self, mv: MetricViewer,
-                 page_size: int,
-                 include: Union[List[str], None],
-                 exclude: Union[List[str], None], **kwargs: Any) -> None:
+    def __init__(
+        self,
+        mv: MetricViewer,
+        page_size: int,
+        include: Union[List[str], None],
+        exclude: Union[List[str], None],
+        **kwargs: Any,
+    ) -> None:
         self._mv = mv
         self._page_size = page_size
         self._include = include
@@ -204,20 +213,19 @@ class MetricServer(Server):
             from plotly import graph_objects as go
 
         @_app.callback(
-            Output(component_id='dependence-figure', component_property='figure'),
-            Input(component_id='dropdown-x', component_property='value'),
-            Input(component_id='dropdown-y', component_property='value'))
+            Output(component_id="dependence-figure", component_property="figure"),
+            Input(component_id="dropdown-x", component_property="value"),
+            Input(component_id="dropdown-y", component_property="value"),
+        )
         def _update_graph(x, y):
             fig = go.Figure()
             if x is not None and y is not None:
                 fig.add_trace(
                     go.Scatter(
-                        x=self._df_flatten[x],
-                        y=self._df_flatten[y],
-                        mode='markers'
+                        x=self._df_flatten[x], y=self._df_flatten[y], mode="markers"
                     )
                 )
-                fig.update_layout(title=f'{x} to {y} relation')
+                fig.update_layout(title=f"{x} to {y} relation")
             return fig
 
     def _layout(self):
@@ -236,46 +244,45 @@ class MetricServer(Server):
             df = df.drop(self._exclude, axis=1)
 
         if self._include is not None:
-            df = df[['line', 'num'] + self._include]
+            df = df[["line", "num"] + self._include]
 
-        self._df_flatten = pd.DataFrame(map(flatten, df.to_dict('records')))
+        self._df_flatten = pd.DataFrame(map(flatten, df.to_dict("records")))
         dep_fig = go.Figure()
 
-        return html.Div([
-            html.H1(
-                children=f'MetricViewer in {self._mv._repo}',
-                style={
-                    'textAlign': 'center',
-                    'color': '#084c61',
-                    'font-family': 'Montserrat'
-                }
-            ),
-            dcc.Dropdown(
-                list(self._df_flatten.columns),
-                id='dropdown-x',
-                multi=False),
-            dcc.Dropdown(
-                list(self._df_flatten.columns),
-                id='dropdown-y',
-                multi=False),
-            dcc.Graph(
-                id='dependence-figure',
-                figure=dep_fig),
-            dash_table.DataTable(
-                columns=[
-                    {'name': col, 'id': col, 'selectable': True} for col in self._df_flatten.columns
-                ],
-                data=self._df_flatten.to_dict('records'),
-                filter_action="native",
-                sort_action="native",
-                sort_mode="multi",
-                selected_columns=[],
-                selected_rows=[],
-                page_action="native",
-                page_current=0,
-                page_size=self._page_size,
-            )
-        ])
+        return html.Div(
+            [
+                html.H1(
+                    children=f"MetricViewer in {self._mv._repo}",
+                    style={
+                        "textAlign": "center",
+                        "color": "#084c61",
+                        "font-family": "Montserrat",
+                    },
+                ),
+                dcc.Dropdown(
+                    list(self._df_flatten.columns), id="dropdown-x", multi=False
+                ),
+                dcc.Dropdown(
+                    list(self._df_flatten.columns), id="dropdown-y", multi=False
+                ),
+                dcc.Graph(id="dependence-figure", figure=dep_fig),
+                dash_table.DataTable(
+                    columns=[
+                        {"name": col, "id": col, "selectable": True}
+                        for col in self._df_flatten.columns
+                    ],
+                    data=self._df_flatten.to_dict("records"),
+                    filter_action="native",
+                    sort_action="native",
+                    sort_mode="multi",
+                    selected_columns=[],
+                    selected_rows=[],
+                    page_action="native",
+                    page_current=0,
+                    page_size=self._page_size,
+                ),
+            ]
+        )
 
     def serve(self, **kwargs: Any) -> None:
         # Conditional import

--- a/cascade/models/__init__.py
+++ b/cascade/models/__init__.py
@@ -16,6 +16,6 @@ limitations under the License.
 
 from .model import Model, ModelModifier
 from .basic_model import BasicModel, BasicModelModifier
-from .model_repo import ModelRepo
+from .model_repo import ModelRepo, SingleLineRepo
 from .model_line import ModelLine
 from .trainer import Trainer, BasicTrainer

--- a/cascade/models/model_line.py
+++ b/cascade/models/model_line.py
@@ -31,8 +31,14 @@ class ModelLine(Traceable):
     A line of models is typically a models with the same hyperparameters and architecture,
     but different epochs or using different data.
     """
-    def __init__(self, folder: str, model_cls: Type = Model,
-                 meta_fmt: Literal['.json', '.yml', '.yaml'] = '.json', **kwargs: Any) -> None:
+
+    def __init__(
+        self,
+        folder: str,
+        model_cls: Type = Model,
+        meta_fmt: Literal[".json", ".yml", ".yaml"] = ".json",
+        **kwargs: Any,
+    ) -> None:
         """
         All models in line should be instances of the same class.
 
@@ -51,17 +57,18 @@ class ModelLine(Traceable):
         """
         super().__init__(**kwargs)
 
-        assert meta_fmt in supported_meta_formats, \
-            f'Only {supported_meta_formats} are supported formats'
+        assert (
+            meta_fmt in supported_meta_formats
+        ), f"Only {supported_meta_formats} are supported formats"
         self._meta_fmt = meta_fmt
         self._model_cls = model_cls
-        self.root = folder
+        self._root = folder
         self.model_names = []
         if os.path.exists(self.root):
             self._load()
         else:
             # No folder -> create
-            os.mkdir(self.root)
+            os.mkdir(self._root)
         self._mh = MetaHandler()
 
     def __getitem__(self, num: int) -> Model:
@@ -74,7 +81,7 @@ class ModelLine(Traceable):
                 a loaded model
         """
         model = self._model_cls()
-        model.load(os.path.join(self.root, self.model_names[num]))
+        model.load(os.path.join(self._root, self.model_names[num]))
         return model
 
     def __len__(self) -> int:
@@ -104,11 +111,11 @@ class ModelLine(Traceable):
             Flag, that indicates whether to save model's binaries. If True saves only metadata.
         """
         idx = len(self.model_names)
-        folder_name = f'{idx:0>5d}'
-        full_path = os.path.join(self.root, folder_name, 'model')
+        folder_name = f"{idx:0>5d}"
+        full_path = os.path.join(self._root, folder_name, "model")
 
         # Create model's folder if no
-        os.makedirs(os.path.join(self.root, folder_name), exist_ok=True)
+        os.makedirs(os.path.join(self._root, folder_name), exist_ok=True)
 
         # Prepare meta for saving
         meta = model.get_meta()
@@ -118,40 +125,46 @@ class ModelLine(Traceable):
             model.save(full_path)
 
             # Find anything that matches /path/model_folder/model*
-            exact_filename = glob.glob(f'{full_path}*')
+            exact_filename = glob.glob(f"{full_path}*")
 
-            assert len(exact_filename) > 0, 'Model file wasn\'t found.\n '
-            'It may be that Model didn\'t save itself when save() was called,'
+            assert len(exact_filename) > 0, "Model file wasn't found.\n "
+            "It may be that Model didn't save itself when save() was called,"
             'or the name of the file didn\'t match "model*"'
 
             exact_filename = exact_filename[0]
-            with open(exact_filename, 'rb') as f:
+            with open(exact_filename, "rb") as f:
                 md5sum = md5(f.read()).hexdigest()
 
-            meta[0]['name'] = exact_filename
-            meta[0]['md5sum'] = md5sum
+            meta[0]["name"] = exact_filename
+            meta[0]["md5sum"] = md5sum
 
-        meta[0]['saved_at'] = pendulum.now(tz='UTC')
-        self.model_names.append(os.path.join(folder_name, 'model'))
+        meta[0]["saved_at"] = pendulum.now(tz="UTC")
+        self.model_names.append(os.path.join(folder_name, "model"))
 
         # Save model's meta
-        self._mh.write(os.path.join(self.root, folder_name, 'meta' + self._meta_fmt), meta)
+        self._mh.write(
+            os.path.join(self._root, folder_name, "meta" + self._meta_fmt), meta
+        )
 
         # Save updated line's meta
-        self._mh.write(os.path.join(self.root, 'meta' + self._meta_fmt), self.get_meta())
+        self._mh.write(
+            os.path.join(self._root, "meta" + self._meta_fmt), self.get_meta()
+        )
 
     def __repr__(self) -> str:
-        return f'ModelLine of {len(self)} models of {self._model_cls}'
+        return f"ModelLine of {len(self)} models of {self._model_cls}"
 
     def get_meta(self) -> PipeMeta:
         meta = super().get_meta()
-        meta[0].update({
-            'root': self.root,
-            'model_cls': repr(self._model_cls),
-            'len': len(self),
-            'updated_at': pendulum.now(tz='UTC'),
-            'type': 'line'
-        })
+        meta[0].update(
+            {
+                "root": self._root,
+                "model_cls": repr(self._model_cls),
+                "len": len(self),
+                "updated_at": pendulum.now(tz="UTC"),
+                "type": "line",
+            }
+        )
         return meta
 
     def _load(self):
@@ -168,3 +181,6 @@ class ModelLine(Traceable):
 
     def reload(self):
         self._load()
+
+    def get_root(self):
+        return self._root

--- a/cascade/models/model_line.py
+++ b/cascade/models/model_line.py
@@ -58,17 +58,7 @@ class ModelLine(Traceable):
         self.root = folder
         self.model_names = []
         if os.path.exists(self.root):
-            assert os.path.isdir(self.root), f'folder should be directory, got `{folder}`'
-            self.model_names = sorted(
-                [os.path.join(model_folder, 'model')
-                    for model_folder in os.listdir(self.root)
-                    if os.path.isdir(os.path.join(self.root, model_folder))])
-
-            if len(self.model_names) == 0:
-                warnings.warn(
-                    f'Model folders were not found by the line in {self.root}'
-                )
-
+            self._load()
         else:
             # No folder -> create
             os.mkdir(self.root)
@@ -163,3 +153,18 @@ class ModelLine(Traceable):
             'type': 'line'
         })
         return meta
+
+    def _load(self):
+        assert os.path.isdir(self.root), f'folder should be directory, got `{self.root}`'
+        self.model_names = sorted(
+            [os.path.join(model_folder, 'model')
+                for model_folder in os.listdir(self.root)
+                if os.path.isdir(os.path.join(self.root, model_folder))])
+
+        if len(self.model_names) == 0:
+            warnings.warn(
+                f'Model folders were not found by the line in {self.root}'
+            )
+
+    def reload(self):
+        self._load()

--- a/cascade/models/model_repo.py
+++ b/cascade/models/model_repo.py
@@ -43,6 +43,37 @@ class Repo(Traceable):
         raise NotImplementedError()
 
     def __len__(self) -> int:
+        """
+        Returns
+        -------
+        num: int
+            a number of lines
+        """
+        return len(self._lines)
+
+    def __iter__(self) -> Generator[ModelLine, None, None]:
+        for line in self._lines:
+            yield self.__getitem__(line)
+
+    def get_meta(self) -> PipeMeta:
+        meta = super().get_meta()
+        meta[0].update({
+            'root': self._root,
+            'len': len(self),
+            'type': 'repo'
+        })
+        return meta
+
+
+class SingleLineRepo(Repo):
+    def __init__(self, line, *args: Any, meta_prefix: Union[Dict[Any, Any], str, None] = None, **kwargs: Any) -> None:
+        super().__init__(*args, meta_prefix=meta_prefix, **kwargs)
+        self._lines = line
+
+    def reload(self) -> None:
+        raise NotImplementedError()
+
+    def __getitem__(self, key: str) -> ModelLine:
         raise NotImplementedError()
 
 
@@ -198,19 +229,6 @@ class ModelRepo(Repo):
         else:
             raise TypeError(f'{type(key)} is not supported as key')
 
-    def __iter__(self) -> Generator[ModelLine, None, None]:
-        for line in self._lines:
-            yield self.__getitem__(line)
-
-    def __len__(self) -> int:
-        """
-        Returns
-        -------
-        num: int
-            a number of lines
-        """
-        return len(self._lines)
-
     def __repr__(self) -> str:
         return f'ModelRepo in {self._root} of {len(self)} lines'
 
@@ -240,12 +258,7 @@ class ModelRepo(Repo):
 
     def get_meta(self) -> PipeMeta:
         meta = super().get_meta()
-        meta[0].update({
-            'root': self._root,
-            'len': len(self),
-            'updated_at': pendulum.now(tz='UTC'),
-            'type': 'repo'
-        })
+        meta[0].update({'updated_at': pendulum.now(tz='UTC')})
         return meta
 
     def reload(self) -> None:

--- a/cascade/models/model_repo.py
+++ b/cascade/models/model_repo.py
@@ -34,7 +34,7 @@ class Repo(Traceable):
     --------
     cascade.models.ModelRepo
     """
-    root = None
+    _root = None
 
     def reload(self) -> None:
         raise NotImplementedError()

--- a/cascade/models/model_repo.py
+++ b/cascade/models/model_repo.py
@@ -76,11 +76,14 @@ class Repo(Traceable):
 class SingleLineRepo(Repo):
     def __init__(self, line, *args: Any, meta_prefix: Union[Dict[Any, Any], str, None] = None, **kwargs: Any) -> None:
         super().__init__(*args, meta_prefix=meta_prefix, **kwargs)
-        self._lines = [line]
+        self._lines = {os.path.split(line.root)[-1]: line}
         self._root = line.root
 
     def __getitem__(self, key: str) -> ModelLine:
         return self._lines[key]
+
+    def __repr__(self):
+        return f'SingleLine in {self._root}'
 
 
 class ModelRepo(Repo):

--- a/cascade/models/model_repo.py
+++ b/cascade/models/model_repo.py
@@ -34,8 +34,11 @@ class Repo(Traceable):
     --------
     cascade.models.ModelRepo
     """
-    _root = None
     _lines = dict()
+    _root = None
+    
+    def get_root(self):
+        return self._root
 
     def reload(self) -> None:
         for line in self._lines:


### PR DESCRIPTION
- Fixes root parameter naming
- MetricViewer and HistoryViewer now support lines as repos seamlessly
- If you need to wrap your line as repo use cascade.models.SingleLineRepo
- Adds ModelLine.get_root and ModelRepo.get_root
