### PR TITLE
Model save load

### DIFF
--- a/cascade/models/model.py
+++ b/cascade/models/model.py
@@ -30,11 +30,10 @@ class Model(Traceable):
                  meta_prefix: Union[PipeMeta, str, None] = None, **kwargs: Any) -> None:
         """
         Should be called in any successor - initializes default meta needed.
-        Arguments passed in it should be related to model's hyperparameters, architecture.
-        All additional arguments should have defaults - to be able to create model and then load.
+
         Successors may pass all of their parameters to superclass for it to be able to
         log them in meta. Everything that is worth to document about model and data
-        it was trained on can be either in params or meta_prefix.
+        it was trained on can be put either in params or meta_prefix.
         """
         # Model accepts meta_prefix explicitly to not to record it in 'params'
         self.metrics = {}
@@ -62,14 +61,14 @@ class Model(Traceable):
         """
         raise_not_implemented('cascade.models.Model', 'evaluate')
 
-    def load(self, filepath: str, *args: Any, **kwargs: Any) -> None:
+    @classmethod
+    def load(cls, path: str, *args: Any, **kwargs: Any) -> 'Model':
         """
-        Loads model from provided filepath. May be unpickling process or reading json configs.
-        Does not return any model, just restores internal state.
+        Loads model from provided path
         """
         raise_not_implemented('cascade.models.Model', 'load')
 
-    def save(self, filepath: str, *args: Any, **kwargs: Any) -> None:
+    def save(self, path: str, *args: Any, **kwargs: Any) -> None:
         """
         Saves model's state using provided filepath.
         """
@@ -81,6 +80,7 @@ class Model(Traceable):
 
         meta = super().get_meta()
 
+        #TODO: can refactor this
         all_default_exist = True
         if hasattr(self, 'created_at'):
             meta[0]['created_at'] = self.created_at

--- a/cascade/models/model_line.py
+++ b/cascade/models/model_line.py
@@ -79,8 +79,7 @@ class ModelLine(Traceable):
             model: Model
                 a loaded model
         """
-        model = self._model_cls()
-        model.load(os.path.join(self._root, self.model_names[num]))
+        model = self._model_cls.load(os.path.join(self._root, self.model_names[num]))
         return model
 
     def __len__(self) -> int:

--- a/cascade/tests/conftest.py
+++ b/cascade/tests/conftest.py
@@ -45,15 +45,14 @@ class DummyModel(Model):
     def evaluate(self, *args, **kwargs):
         self.metrics.update({'acc': np.random.random()})
 
-    def load(self, path):
-        if os.path.splitext(path)[-1] != '.bin':
-            path += '.bin'
+    @classmethod
+    def load(cls, path):
         with open(path, 'rb') as f:
-            self.model = str(f.read())
+            model = DummyModel()
+            model.model = str(f.read())
+            return model
 
     def save(self, path):
-        if os.path.splitext(path)[-1] != '.bin':
-            path += '.bin'
         with open(path, 'wb') as f:
             f.write(b'model')
 
@@ -67,8 +66,9 @@ class OnesModel(BasicModel):
     def predict(self, x, *args, **kwargs):
         return np.array([1 for _ in range(len(x))])
 
-    def load(self, filepath) -> None:
-        pass
+    @classmethod
+    def load(cls, filepath) -> "OnesModel":
+        return OnesModel()
 
     def save(self, filepath) -> None:
         pass

--- a/cascade/tests/test_metric_viewer.py
+++ b/cascade/tests/test_metric_viewer.py
@@ -111,8 +111,9 @@ def test_get_best_by(tmp_path, ext):
 )
 def test_get_best_by_non_sortable(tmp_path, ext):
     class ModelComplexMetric(BasicModel):
-        def load(self, *args, **kwargs):
-            pass
+        @classmethod
+        def load(cls, *args, **kwargs) -> "ModelComplexMetric":
+            return ModelComplexMetric()
 
         def predict(self, *args, **kwargs):
             return None

--- a/cascade/utils/baselines.py
+++ b/cascade/utils/baselines.py
@@ -50,7 +50,9 @@ class ConstantBaseline(BasicModel):
         with open(path, 'w') as f:
             json.dump({'constant': self._constant}, f)
 
-    def load(self, path: str) -> None:
+    @classmethod
+    def load(cls, path: str) -> "ConstantBaseline":
         with open(path, 'r') as f:
             obj = json.load(f)
-            self._constant = obj['constant']
+            model = ConstantBaseline(obj['constant'])
+            return model

--- a/cascade/utils/sk_model.py
+++ b/cascade/utils/sk_model.py
@@ -70,7 +70,8 @@ class SkModel(BasicModel):
         """
         return self._pipeline.predict_proba(x, *args, **kwargs)
 
-    def _check_model_hash(self, path: str) -> None:
+    @classmethod
+    def _check_model_hash(cls, path: str) -> None:
         root = os.path.dirname(path)
         names = glob.glob(os.path.join(f"{root}", "meta.*"))
         if len(names) == 1:
@@ -91,7 +92,8 @@ class SkModel(BasicModel):
         elif len(names) > 1:
             raise RuntimeError(f"Multiple possible meta-files found: {names}")
 
-    def load(self, path: str, check_hash: bool = True) -> None:
+    @classmethod
+    def load(cls, path: str, check_hash: bool = True) -> 'SkModel':
         """
         Loads the model from path provided. Path may be a folder,
         if so, model.pkl is assumed.
@@ -108,10 +110,12 @@ class SkModel(BasicModel):
         path = path + ext
 
         if check_hash:
-            self._check_model_hash(path)
+            cls._check_model_hash(path)
 
         with open(path, "rb") as f:
-            self._pipeline = pickle.load(f)
+            model = pickle.load(f)
+
+        return model
 
     def save(self, path: str) -> None:
         """
@@ -133,7 +137,7 @@ class SkModel(BasicModel):
         path = path + ext
 
         with open(f"{path}", "wb") as f:
-            pickle.dump(self._pipeline, f)
+            pickle.dump(self.__dict__, f)
 
     def get_meta(self) -> PipeMeta:
         meta = super().get_meta()

--- a/cascade/utils/tests/test_sk_model.py
+++ b/cascade/utils/tests/test_sk_model.py
@@ -68,5 +68,4 @@ def test_save_load(tmp_path, postfix):
 
     model.save(tmp_path)
 
-    model = SkModel()
-    model.load(tmp_path)
+    model = SkModel.load(tmp_path)

--- a/cascade/utils/tests/test_torch_model.py
+++ b/cascade/utils/tests/test_torch_model.py
@@ -1,0 +1,45 @@
+"""
+Copyright 2022-2023 Ilia Moiseev
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import os
+import sys
+import torch
+import pytest
+
+
+MODULE_PATH = os.path.dirname(
+    os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
+)
+sys.path.append(os.path.dirname(MODULE_PATH))
+
+
+from cascade.utils.torch_model import TorchModel
+
+
+@pytest.mark.parametrize("postfix", ["", "model", "model.pt"])
+def test_save_load(tmp_path, postfix):
+    tmp_path = str(tmp_path)
+
+    if postfix:
+        tmp_path = os.path.join(tmp_path, postfix)
+
+    model = TorchModel(torch.nn.Linear, in_features=10, out_features=2)
+
+    model.save(tmp_path)
+
+    model = TorchModel.load(tmp_path)
+
+    assert str(model._model) == str(torch.nn.Linear(10, 2))


### PR DESCRIPTION
Changes how models are saved
- load() now is a `classmethod`
  - The above implies that old-way usage should still be valid
  - but limitations on default constructors are now lifted
  - and new-way should be used from now on
- save can accept folders now (which should be the standard in the first place)
- TorchModel now saves the whole object and loads itself