### PR TITLE
Check if model already exists to not overwrite in line

### DIFF
--- a/cascade/tests/test_model_line.py
+++ b/cascade/tests/test_model_line.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 import glob
 import os
+import shutil
 import sys
 
 import pytest
@@ -53,3 +54,15 @@ def test_change_of_format(tmp_path, ext):
 
     # Check that no other meta is created
     assert len(glob.glob(os.path.join(tmp_path, "meta.*"))) == 1
+
+
+def test_same_index_check(model_line, dummy_model):
+    for _ in range(3):
+        dummy_model.evaluate()
+        model_line.save(dummy_model)
+
+    shutil.rmtree(os.path.join(model_line.get_root(), "00001"))
+
+    model_line.save(dummy_model)
+
+    assert os.path.exists(os.path.join(model_line.get_root(), "00003"))


### PR DESCRIPTION
Earlier if you delete something in the middle of the line it would start to overwrite old models since latest index = length
Now line will count until it finds latest model