### PR TITLE
New model load

### DIFF
--- a/cascade/models/basic_model.py
+++ b/cascade/models/basic_model.py
@@ -15,9 +15,12 @@ limitations under the License.
 """
 
 
-from typing import Any, Callable, Dict
+import glob
+import pickle
+import os
 
-from ..base import raise_not_implemented
+from typing import Dict, Callable, Any
+from ..base import raise_not_implemented, MetaHandler
 from .model import Model, ModelModifier
 
 
@@ -66,6 +69,74 @@ class BasicModel(Model):
         """
         preds = self.predict(x, *args, **kwargs)
         self.metrics.update({key: metrics_dict[key](y, preds) for key in metrics_dict})
+
+    @classmethod
+    def _check_model_hash(cls, path: str) -> None:
+        root = os.path.dirname(path)
+        names = glob.glob(os.path.join(f"{root}", "meta.*"))
+        if len(names) == 1:
+            meta = MetaHandler.read(names[0])
+            # Uses first meta in list
+            # Usually the list is of unit length
+            meta = meta[0]
+            if "md5sum" in meta:
+                with open(path, "rb") as f:
+                    file_hash = md5(f.read()).hexdigest()
+                if file_hash != meta["md5sum"]:
+                    raise RuntimeError(
+                        f".pkl model hash check failed "
+                        f"it may be that model's .pkl file was corrupted\n"
+                        f'hash from {names[0]}: {meta["md5sum"]}\n'
+                        f"hash of {path}: {file_hash}"
+                    )
+        elif len(names) > 1:
+            raise RuntimeError(f"Multiple possible meta-files found: {names}")
+
+    @classmethod
+    def load(cls, path: str, check_hash: bool = True) -> "BasicModel":
+        """
+        Loads the model from path provided. Path may be a folder,
+        if so, model.pkl is assumed.
+
+        If path is the file with no extension, .pkl is added.
+        """
+        if os.path.isdir(path):
+            path = os.path.join(path, "model.pkl")
+
+        path, ext = os.path.splitext(path)
+        if ext == "":
+            ext += ".pkl"
+
+        path = path + ext
+
+        if check_hash:
+            cls._check_model_hash(path)
+
+        with open(path, "rb") as f:
+            model = pickle.load(f)
+        return model
+
+    def save(self, path: str) -> None:
+        """
+        Saves model to the path provided.
+        If path is a folder, then creates
+        it if not exists and saves there as
+        model.pkl
+        If path is a file, then saves it accordingly.
+        If no extension of file provided, then .pkl is added.
+        """
+        if os.path.isdir(path):
+            os.makedirs(path, exist_ok=True)
+            path = os.path.join(path, "model.pkl")
+
+        path, ext = os.path.splitext(path)
+        if ext == "":
+            ext += ".pkl"
+
+        path = path + ext
+
+        with open(path, "wb") as f:
+            pickle.dump(self, f)
 
 
 class BasicModelModifier(ModelModifier, BasicModel):

--- a/cascade/models/basic_model.py
+++ b/cascade/models/basic_model.py
@@ -47,7 +47,7 @@ class BasicModel(Model):
         y: Any,
         metrics_dict: Dict[str, Callable],
         *args: Any,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         """
         Receives x and y validation sequences. Passes x to the model's predict
@@ -96,21 +96,14 @@ class BasicModel(Model):
     def load(cls, path: str, check_hash: bool = True) -> "BasicModel":
         """
         Loads the model from path provided. Path may be a folder,
-        if so, model.pkl is assumed.
-
-        If path is the file with no extension, .pkl is added.
+        if so, `model` is assumed.
         """
         if os.path.isdir(path):
-            path = os.path.join(path, "model.pkl")
+            path = os.path.join(path, "model")
 
-        path, ext = os.path.splitext(path)
-        if ext == "":
-            ext += ".pkl"
-
-        path = path + ext
-
-        if check_hash:
-            cls._check_model_hash(path)
+        # TODO: enable hash check later
+        # if check_hash:
+        #     cls._check_model_hash(path)
 
         with open(path, "rb") as f:
             model = pickle.load(f)
@@ -121,19 +114,12 @@ class BasicModel(Model):
         Saves model to the path provided.
         If path is a folder, then creates
         it if not exists and saves there as
-        model.pkl
+        `model`
         If path is a file, then saves it accordingly.
-        If no extension of file provided, then .pkl is added.
         """
         if os.path.isdir(path):
             os.makedirs(path, exist_ok=True)
-            path = os.path.join(path, "model.pkl")
-
-        path, ext = os.path.splitext(path)
-        if ext == "":
-            ext += ".pkl"
-
-        path = path + ext
+            path = os.path.join(path, "model")
 
         with open(path, "wb") as f:
             pickle.dump(self, f)

--- a/cascade/tests/test_basic_model.py
+++ b/cascade/tests/test_basic_model.py
@@ -18,12 +18,13 @@ import os
 import random
 import sys
 
+import pytest
 import numpy as np
 
 MODULE_PATH = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
 sys.path.append(os.path.dirname(MODULE_PATH))
 
-from cascade.models import BasicModelModifier
+from cascade.models import BasicModelModifier, BasicModel
 
 
 def test_basic_model_with_concrete_case(ones_model):
@@ -75,3 +76,16 @@ def test_modifier(ones_model):
 
     assert all(y == [2, 2, 2])
     assert len(meta) == 2
+
+
+@pytest.mark.parametrize("postfix", ["", "model", "model.pkl"])
+def test_save_load(tmp_path, postfix):
+    tmp_path = str(tmp_path)
+
+    if postfix:
+        tmp_path = os.path.join(tmp_path, postfix)
+
+    model = BasicModel(a=10)
+    model.save(tmp_path)
+    model = BasicModel.load(tmp_path)
+    assert model.params.get('a') == 10

--- a/cascade/utils/sk_model.py
+++ b/cascade/utils/sk_model.py
@@ -111,6 +111,13 @@ class SkModel(BasicModel):
         model.pkl
         If path is a file, then saves it accordingly.
         If no extension of file provided, then .pkl is added.
+
+        The model is saved in two parts - the wrapper without pipeline
+        and the actual sklearn model as pipeline separately.
+        This is done for artifact portability - you can use pipeline in
+        deployments directly without the need to bring additional dependency
+        with the wrapper. At the same time additional params can still be loaded
+        using wrapper that is saved nearby.
         """
         if os.path.isdir(path):
             os.makedirs(path, exist_ok=True)

--- a/cascade/utils/sk_model.py
+++ b/cascade/utils/sk_model.py
@@ -114,9 +114,8 @@ class SkModel(BasicModel):
             cls._check_model_hash(path)
 
         with open(path, "rb") as f:
-            pipeline = pickle.load(f)
-            model = SkModel(blocks=pipeline)
-
+            model = SkModel()
+            model._pipeline = pickle.load(f)
         return model
 
     def save(self, path: str) -> None:

--- a/cascade/utils/sk_model.py
+++ b/cascade/utils/sk_model.py
@@ -72,28 +72,6 @@ class SkModel(BasicModel):
         return self._pipeline.predict_proba(x, *args, **kwargs)
 
     @classmethod
-    def _check_model_hash(cls, path: str) -> None:
-        root = os.path.dirname(path)
-        names = glob.glob(os.path.join(f"{root}", "meta.*"))
-        if len(names) == 1:
-            meta = MetaHandler.read(names[0])
-            # Uses first meta in list
-            # Usually the list is of unit length
-            meta = meta[0]
-            if "md5sum" in meta:
-                with open(path, "rb") as f:
-                    file_hash = md5(f.read()).hexdigest()
-                if file_hash != meta["md5sum"]:
-                    raise RuntimeError(
-                        f".pkl model hash check failed "
-                        f"it may be that model's .pkl file was corrupted\n"
-                        f'hash from {names[0]}: {meta["md5sum"]}\n'
-                        f"hash of {path}: {file_hash}"
-                    )
-        elif len(names) > 1:
-            raise RuntimeError(f"Multiple possible meta-files found: {names}")
-
-    @classmethod
     def load(cls, path: str, check_hash: bool = True) -> "SkModel":
         """
         Loads the model from path provided. Path may be a folder,

--- a/cascade/utils/sk_model.py
+++ b/cascade/utils/sk_model.py
@@ -114,7 +114,8 @@ class SkModel(BasicModel):
             cls._check_model_hash(path)
 
         with open(path, "rb") as f:
-            model = pickle.load(f)
+            pipeline = pickle.load(f)
+            model = SkModel(blocks=pipeline)
 
         return model
 
@@ -138,7 +139,7 @@ class SkModel(BasicModel):
         path = path + ext
 
         with open(f"{path}", "wb") as f:
-            pickle.dump(self.__dict__, f)
+            pickle.dump(self._pipeline, f)
 
     def get_meta(self) -> PipeMeta:
         meta = super().get_meta()

--- a/cascade/utils/sk_model.py
+++ b/cascade/utils/sk_model.py
@@ -80,19 +80,26 @@ class SkModel(BasicModel):
         If path is the file with no extension, .pkl is added.
         """
         if os.path.isdir(path):
-            path = os.path.join(path, "model.pkl")
+            os.makedirs(path, exist_ok=True)
+            model_path = os.path.join(path, "model.pkl")
+            pipeline_path = os.path.join(path, "pipeline.pkl")
+        else:
+            model_path = path
+            pipeline_path = os.path.join(*os.path.split(path)[:-1], "pipeline.pkl")
 
-        path, ext = os.path.splitext(path)
+        model_path, ext = os.path.splitext(model_path)
         if ext == "":
             ext += ".pkl"
+        model_path = model_path + ext
 
-        path = path + ext
+        # TODO: enable check again later
+        # if check_hash:
+        #     cls._check_model_hash(model_path)
 
-        if check_hash:
-            cls._check_model_hash(path)
+        with open(model_path, "rb") as f:
+            model = pickle.load(f)
 
-        with open(path, "rb") as f:
-            model = SkModel()
+        with open(pipeline_path, "rb") as f:
             model._pipeline = pickle.load(f)
         return model
 
@@ -107,16 +114,24 @@ class SkModel(BasicModel):
         """
         if os.path.isdir(path):
             os.makedirs(path, exist_ok=True)
-            path = os.path.join(path, "model.pkl")
+            model_path = os.path.join(path, "model.pkl")
+            pipeline_path = os.path.join(path, "pipeline.pkl")
+        else:
+            model_path = path
+            pipeline_path = os.path.join(*os.path.split(path)[:-1], "pipeline.pkl")
 
-        path, ext = os.path.splitext(path)
+        model_path, ext = os.path.splitext(model_path)
         if ext == "":
             ext += ".pkl"
+        model_path = model_path + ext
 
-        path = path + ext
-
-        with open(f"{path}", "wb") as f:
+        with open(pipeline_path, "wb") as f:
             pickle.dump(self._pipeline, f)
+
+        del self._pipeline
+
+        with open(model_path, "wb") as f:
+            pickle.dump(self, f)
 
     def get_meta(self) -> PipeMeta:
         meta = super().get_meta()

--- a/cascade/utils/tests/test_sk_model.py
+++ b/cascade/utils/tests/test_sk_model.py
@@ -61,12 +61,9 @@ def test_hash_check(tmp_path, ext):
 @pytest.mark.parametrize("postfix", ["", "model", "model.pkl"])
 def test_save_load(tmp_path, postfix):
     tmp_path = str(tmp_path)
-
     if postfix:
         tmp_path = os.path.join(tmp_path, postfix)
 
     model = SkModel(blocks=[RandomForestClassifier()])
-
     model.save(tmp_path)
-
     model = SkModel.load(tmp_path)

--- a/cascade/utils/tests/test_sk_model.py
+++ b/cascade/utils/tests/test_sk_model.py
@@ -64,6 +64,9 @@ def test_save_load(tmp_path, postfix):
     if postfix:
         tmp_path = os.path.join(tmp_path, postfix)
 
-    model = SkModel(blocks=[RandomForestClassifier()])
+    model = SkModel(blocks=[RandomForestClassifier(n_estimators=2)], custom_param=42)
     model.save(tmp_path)
     model = SkModel.load(tmp_path)
+
+    assert model.params.get("custom_param") == 42
+    assert model._pipeline[0].n_estimators == 2

--- a/cascade/utils/tests/test_torch_model.py
+++ b/cascade/utils/tests/test_torch_model.py
@@ -43,3 +43,5 @@ def test_save_load(tmp_path, postfix):
     model = TorchModel.load(tmp_path)
 
     assert str(model._model) == str(torch.nn.Linear(10, 2))
+    assert model.params.get("in_features") == 10
+    assert model.params.get("out_features") == 2


### PR DESCRIPTION
Default `BasicModel` saving and loading is now held automatically using `pickle`.
`TorchModel` and `SkModel` save the checkpoint separately and the model without it. When loading they are reassembled. 