### PR TITLE
Separate artifacts from wrappers

### DIFF
--- a/cascade/models/basic_model.py
+++ b/cascade/models/basic_model.py
@@ -97,10 +97,11 @@ class BasicModel(Model):
     def load(cls, path: str, check_hash: bool = True) -> "BasicModel":
         """
         Loads the model from path provided. Path may be a folder,
-        if so, `model` is assumed.
+        if so, `model.pkl` is assumed.
         """
-        if os.path.isdir(path):
-            path = os.path.join(path, "model")
+        if not os.path.isdir(path):
+            raise ValueError(f"Error when loading a model - {path} is not a folder")
+        path = os.path.join(path, "model.pkl")
 
         # TODO: enable hash check later
         # if check_hash:
@@ -112,18 +113,25 @@ class BasicModel(Model):
 
     def save(self, path: str) -> None:
         """
-        Saves model to the path provided.
-        If path is a folder, then creates
-        it if not exists and saves there as
-        `model`
-        If path is a file, then saves it accordingly.
+        Saves model to the path provided
+        Path should be a folder, which will be created
+        if not exists and saves there as `model.pkl`
         """
-        if os.path.isdir(path):
-            os.makedirs(path, exist_ok=True)
-            path = os.path.join(path, "model")
+        if not os.path.isdir(path):
+            raise ValueError(f"Error when saving a model - {path} is not a folder")
+
+        os.makedirs(path, exist_ok=True)
+        path = os.path.join(path, "model.pkl")
 
         with open(path, "wb") as f:
             pickle.dump(self, f)
+
+    def save_artifact(self, path: str, *args: Any, **kwargs: Any) -> None:
+        """
+        BasicModel implements this for compatibility.
+        This method does nothing since there are no internal artifacts in BasicModel
+        """
+        pass
 
 
 class BasicModelModifier(ModelModifier, BasicModel):

--- a/cascade/models/basic_model.py
+++ b/cascade/models/basic_model.py
@@ -133,6 +133,13 @@ class BasicModel(Model):
         """
         pass
 
+    def load_artifact(self, path: str, *args: Any, **kwargs: Any) -> None:
+        """
+        BasicModel implements this for compatibility.
+        This method does nothing since there are no internal artifacts in BasicModel
+        """
+        pass
+
 
 class BasicModelModifier(ModelModifier, BasicModel):
     """

--- a/cascade/models/basic_model.py
+++ b/cascade/models/basic_model.py
@@ -96,8 +96,7 @@ class BasicModel(Model):
     @classmethod
     def load(cls, path: str, check_hash: bool = True) -> "BasicModel":
         """
-        Loads the model from path provided. Path may be a folder,
-        if so, `model.pkl` is assumed.
+        Loads the model from path provided. Path should be a folder
         """
         if not os.path.isdir(path):
             raise ValueError(f"Error when loading a model - {path} is not a folder")

--- a/cascade/models/model.py
+++ b/cascade/models/model.py
@@ -75,9 +75,21 @@ class Model(Traceable):
 
     def save(self, path: str, *args: Any, **kwargs: Any) -> None:
         """
-        Saves model's state using provided filepath.
+        Saves model wrapper's state using provided filepath
         """
         raise_not_implemented("cascade.models.Model", "save")
+
+    def load_artifact(self, path: str, *args: Any, **kwargs: Any) -> None:
+        """
+        Loads standalone model's artifact using provided filepath and sets it inside the model
+        """
+        raise_not_implemented("cascade.models.Model", "load_artifact")
+
+    def save_artifact(self, path: str, *args: Any, **kwargs: Any) -> None:
+        """
+        Saves standalone model's artifact using provided filepath
+        """
+        raise_not_implemented("cascade.models.Model", "save_artifact")
 
     def get_meta(self) -> PipeMeta:
         # Successors may not call super().__init__

--- a/cascade/models/model_line.py
+++ b/cascade/models/model_line.py
@@ -125,18 +125,9 @@ class ModelLine(TraceableOnDisk):
 
         meta = model.get_meta()
 
-        # if not only_meta:
-        #     # Save model
-        #     full_path = os.path.join(self._root, folder_name, "model")
-        #     model.save(full_path)
-
-        #     # Find anything that matches /path/model_folder/model*
-        #     # TODO: need to review this
-        #     exact_filename = glob.glob(f"{full_path}*")
-
-        #     assert len(exact_filename) > 0, "Model file wasn't found.\n "
-        #     "It may be that Model didn't save itself when save() was called,"
-        #     'or the name of the file didn\'t match "model*"'
+        if not only_meta:
+            # Save model
+            model.save(os.path.join(self._root, folder_name))
 
         #     exact_filename = exact_filename[0]
         #     with open(exact_filename, "rb") as f:

--- a/cascade/models/model_line.py
+++ b/cascade/models/model_line.py
@@ -107,10 +107,12 @@ class ModelLine(TraceableOnDisk):
         only_meta: bool, optional
             Flag, that indicates whether to save model's binaries. If True saves only metadata.
         """
+        if len(self.model_names) == 0:
+            idx = 0
+        else:
+            idx = int(max(self.model_names)) + 1
 
-        idx = len(self.model_names)
-        # If models in the middle were deleted
-        # length might not be equal to the latest index
+        # Should check just in case
         while True:
             folder_name = f"{idx:0>5d}"
             model_folder = os.path.join(self._root, folder_name)
@@ -118,7 +120,6 @@ class ModelLine(TraceableOnDisk):
                 idx += 1
                 continue
 
-            # Create model's folder if no
             os.makedirs(model_folder)
             break
 
@@ -146,7 +147,7 @@ class ModelLine(TraceableOnDisk):
 
         meta[0]["path"] = os.path.join(self._root, folder_name)
         meta[0]["saved_at"] = pendulum.now(tz="UTC")
-        self.model_names.append(os.path.join(folder_name, "model"))
+        self.model_names.append(folder_name)
 
         MetaHandler.write(
             os.path.join(self._root, folder_name, "meta" + self._meta_fmt), meta
@@ -175,7 +176,7 @@ class ModelLine(TraceableOnDisk):
         ), f"folder should be directory, got `{self._root}`"
         self.model_names = sorted(
             [
-                os.path.join(model_folder, "model")
+                model_folder
                 for model_folder in os.listdir(self._root)
                 if os.path.isdir(os.path.join(self._root, model_folder))
             ]

--- a/cascade/models/model_line.py
+++ b/cascade/models/model_line.py
@@ -105,7 +105,7 @@ class ModelLine(TraceableOnDisk):
         model: Model
             Model to be saved
         only_meta: bool, optional
-            Flag, that indicates whether to save model's binaries. If True saves only metadata.
+            Flag, that indicates whether to save model's artifacts. If True saves only metadata and wrapper.
         """
         if len(self.model_names) == 0:
             idx = 0
@@ -164,9 +164,9 @@ class ModelLine(TraceableOnDisk):
         return meta
 
     def _load(self):
-        assert os.path.isdir(
-            self._root
-        ), f"folder should be directory, got `{self._root}`"
+        if not os.path.isdir(self._root):
+            raise ValueError(f"folder should be directory, got `{self._root}`")
+
         self.model_names = sorted(
             [
                 model_folder

--- a/cascade/models/model_line.py
+++ b/cascade/models/model_line.py
@@ -123,11 +123,13 @@ class ModelLine(TraceableOnDisk):
             os.makedirs(model_folder)
             break
 
-        meta = model.get_meta()
+        model.save(os.path.join(self._root, folder_name))
 
+        meta = model.get_meta()
         if not only_meta:
-            # Save model
-            model.save(os.path.join(self._root, folder_name))
+            artifacts_folder = os.path.join(self._root, folder_name, "artifacts")
+            os.makedirs(artifacts_folder, exist_ok=True)
+            model.save_artifact(artifacts_folder)
 
         #     exact_filename = exact_filename[0]
         #     with open(exact_filename, "rb") as f:

--- a/cascade/models/trainer.py
+++ b/cascade/models/trainer.py
@@ -15,8 +15,7 @@ limitations under the License.
 """
 
 import logging
-import os
-from typing import Any, Dict, Iterable, List, Union
+from typing import Any, Dict, Iterable, List, Union, Tuple
 
 import pendulum
 
@@ -68,15 +67,14 @@ class BasicTrainer(Trainer):
     """
 
     @staticmethod
-    def _find_last_model(model: Model, line: ModelLine) -> None:
+    def _load_last_model(line: ModelLine) -> Tuple[Model, int]:
         model_num = len(line) - 1
         while True:
-            path = os.path.join(line.get_root(), line.model_names[model_num])
             try:
-                model.load(path)
-                break
-            except FileNotFoundError as e:
-                logger.warning(f"Model {path} files were not found\n{e}")
+                model = line.load(model_num, only_meta=False)
+                return model, model_num
+            except Exception as e:
+                logger.warning(f"Model {model_num} files were not found\n{e}")
                 model_num -= 1
 
                 if model_num == -1:
@@ -148,7 +146,7 @@ class BasicTrainer(Trainer):
         if start_from is not None:
             if len(line) == 0:
                 raise RuntimeError(f"Cannot start from line {line_name} as it is empty")
-            model_num = self._find_last_model(model, line)
+            model, model_num = self._load_last_model(line)
 
         start_time = pendulum.now()
         self._meta_prefix["train_start_at"] = start_time

--- a/cascade/tests/conftest.py
+++ b/cascade/tests/conftest.py
@@ -42,7 +42,7 @@ from cascade.data import (
 from cascade.models import BasicModel, Model, ModelLine, ModelRepo
 
 
-class DummyModel(Model):
+class DummyModel(BasicModel):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.model = b"model"
@@ -56,17 +56,6 @@ class DummyModel(Model):
     def evaluate(self, *args, **kwargs):
         self.metrics.update({"acc": np.random.random()})
 
-    @classmethod
-    def load(cls, path):
-        with open(path, "rb") as f:
-            model = DummyModel()
-            model.model = str(f.read())
-            return model
-
-    def save(self, path):
-        with open(path, "wb") as f:
-            f.write(b"model")
-
 
 class EmptyModel(DummyModel):
     def __init__(self):
@@ -76,13 +65,6 @@ class EmptyModel(DummyModel):
 class OnesModel(BasicModel):
     def predict(self, x, *args, **kwargs):
         return np.array([1 for _ in range(len(x))])
-
-    @classmethod
-    def load(cls, filepath) -> "OnesModel":
-        return OnesModel()
-
-    def save(self, filepath) -> None:
-        pass
 
     def fit(self, x, y, *args, **kwargs) -> None:
         pass

--- a/cascade/tests/conftest.py
+++ b/cascade/tests/conftest.py
@@ -70,6 +70,11 @@ class OnesModel(BasicModel):
         pass
 
 
+class ModelComplexMetric(BasicModel):
+    def predict(self, *args, **kwargs):
+        return None
+
+
 def f(x: int) -> int:
     return 2 * x
 

--- a/cascade/tests/test_basic_model.py
+++ b/cascade/tests/test_basic_model.py
@@ -87,7 +87,7 @@ def test_save_load(tmp_path):
     assert model.params.get("a") == 10
 
 
-def test_model_artifacts():
+def test_model_artifacts(tmp_path):
     tmp_path = str(tmp_path)
 
     model = BasicModel(a=10)

--- a/cascade/tests/test_basic_model.py
+++ b/cascade/tests/test_basic_model.py
@@ -85,3 +85,13 @@ def test_save_load(tmp_path):
     model.save(tmp_path)
     model = BasicModel.load(tmp_path)
     assert model.params.get("a") == 10
+
+
+def test_model_artifacts():
+    tmp_path = str(tmp_path)
+
+    model = BasicModel(a=10)
+
+    # Those should work, but do nothing
+    model.save_artifact(tmp_path)
+    model.load_artifact(tmp_path)

--- a/cascade/tests/test_basic_model.py
+++ b/cascade/tests/test_basic_model.py
@@ -78,14 +78,10 @@ def test_modifier(ones_model):
     assert len(meta) == 2
 
 
-@pytest.mark.parametrize("postfix", ["", "model", "model.pkl"])
-def test_save_load(tmp_path, postfix):
+def test_save_load(tmp_path):
     tmp_path = str(tmp_path)
-
-    if postfix:
-        tmp_path = os.path.join(tmp_path, postfix)
 
     model = BasicModel(a=10)
     model.save(tmp_path)
     model = BasicModel.load(tmp_path)
-    assert model.params.get('a') == 10
+    assert model.params.get("a") == 10

--- a/cascade/tests/test_metric_viewer.py
+++ b/cascade/tests/test_metric_viewer.py
@@ -25,7 +25,7 @@ sys.path.append(os.path.dirname(MODULE_PATH))
 
 from cascade.meta import MetricViewer
 from cascade.models import BasicModel, ModelRepo
-from cascade.tests.conftest import DummyModel
+from cascade.tests.conftest import DummyModel, ModelComplexMetric
 
 
 def test(repo_or_line, dummy_model):
@@ -94,14 +94,6 @@ def test_get_best_by(tmp_path, ext):
 
 @pytest.mark.parametrize("ext", [".json", ".yml", ".yaml"])
 def test_get_best_by_non_sortable(tmp_path, ext):
-    class ModelComplexMetric(BasicModel):
-        @classmethod
-        def load(cls, *args, **kwargs) -> "ModelComplexMetric":
-            return ModelComplexMetric()
-
-        def predict(self, *args, **kwargs):
-            return None
-
     repo = ModelRepo(str(tmp_path), meta_fmt=ext, model_cls=ModelComplexMetric)
     line = repo.add_line("00001", model_cls=ModelComplexMetric)
 

--- a/cascade/tests/test_model_line.py
+++ b/cascade/tests/test_model_line.py
@@ -28,11 +28,15 @@ from cascade.tests.conftest import DummyModel, ModelLine
 
 
 def test_save_load(model_line, dummy_model):
+    dummy_model.a = 0
+    dummy_model.params.update({"b": "test"})
+
     model_line.save(dummy_model)
     model = model_line[0]
 
     assert len(model_line) == 1
-    assert model.model == "b'model'"
+    assert model.a == 0
+    assert model.params["b"] == "test"
 
 
 def test_meta(model_line, dummy_model):

--- a/cascade/tests/test_model_line.py
+++ b/cascade/tests/test_model_line.py
@@ -57,12 +57,14 @@ def test_change_of_format(tmp_path, ext):
 
 
 def test_same_index_check(model_line, dummy_model):
-    for _ in range(3):
+    for _ in range(5):
         dummy_model.evaluate()
         model_line.save(dummy_model)
 
     shutil.rmtree(os.path.join(model_line.get_root(), "00001"))
+    shutil.rmtree(os.path.join(model_line.get_root(), "00002"))
+    shutil.rmtree(os.path.join(model_line.get_root(), "00003"))
 
     model_line.save(dummy_model)
 
-    assert os.path.exists(os.path.join(model_line.get_root(), "00003"))
+    assert os.path.exists(os.path.join(model_line.get_root(), "00005"))

--- a/cascade/tests/test_model_line.py
+++ b/cascade/tests/test_model_line.py
@@ -27,11 +27,12 @@ sys.path.append(os.path.dirname(MODULE_PATH))
 from cascade.tests.conftest import DummyModel, ModelLine
 
 
-def test_save_load(model_line, dummy_model):
+@pytest.mark.parametrize("only_meta", [True, False])
+def test_save_load(model_line, dummy_model, only_meta):
     dummy_model.a = 0
     dummy_model.params.update({"b": "test"})
 
-    model_line.save(dummy_model)
+    model_line.save(dummy_model, only_meta=only_meta)
     model = model_line[0]
 
     assert len(model_line) == 1

--- a/cascade/utils/sklearn/sk_model.py
+++ b/cascade/utils/sklearn/sk_model.py
@@ -14,15 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import glob
 import os
 import pickle
-from hashlib import md5
 from typing import Any, List, Union
 
 from sklearn.pipeline import Pipeline
 
-from ...base import MetaHandler, PipeMeta
+from ...base import PipeMeta
 from ...models import BasicModel
 
 
@@ -71,74 +69,73 @@ class SkModel(BasicModel):
         """
         return self._pipeline.predict_proba(x, *args, **kwargs)
 
-    @classmethod
-    def load(cls, path: str, check_hash: bool = True) -> "SkModel":
-        """
-        Loads the model from path provided. Path may be a folder,
-        if so, model.pkl is assumed.
-
-        If path is the file with no extension, .pkl is added.
-        """
-        if os.path.isdir(path):
-            os.makedirs(path, exist_ok=True)
-            model_path = os.path.join(path, "model.pkl")
-            pipeline_path = os.path.join(path, "pipeline.pkl")
-        else:
-            model_path = path
-            pipeline_path = os.path.join(*os.path.split(path)[:-1], "pipeline.pkl")
-
-        model_path, ext = os.path.splitext(model_path)
-        if ext == "":
-            ext += ".pkl"
-        model_path = model_path + ext
-
-        # TODO: enable check again later
-        # if check_hash:
-        #     cls._check_model_hash(model_path)
-
-        with open(model_path, "rb") as f:
-            model = pickle.load(f)
-
-        with open(pipeline_path, "rb") as f:
-            model._pipeline = pickle.load(f)
-        return model
-
     def save(self, path: str) -> None:
         """
         Saves model to the path provided.
-        If path is a folder, then creates
+        Path should be a folder. Creates
         it if not exists and saves there as
         model.pkl
-        If path is a file, then saves it accordingly.
-        If no extension of file provided, then .pkl is added.
 
-        The model is saved in two parts - the wrapper without pipeline
-        and the actual sklearn model as pipeline separately.
-        This is done for artifact portability - you can use pipeline in
-        deployments directly without the need to bring additional dependency
-        with the wrapper. At the same time additional params can still be loaded
-        using wrapper that is saved nearby.
+        When saving using this method only wrapper is saved
+        if you want to save sklearn model use save_artifact
+
+        See also
+        --------
+        cascade.utils.sklearn.SkModel.save_artifact
         """
-        if os.path.isdir(path):
-            os.makedirs(path, exist_ok=True)
-            model_path = os.path.join(path, "model.pkl")
-            pipeline_path = os.path.join(path, "pipeline.pkl")
-        else:
-            model_path = path
-            pipeline_path = os.path.join(*os.path.split(path)[:-1], "pipeline.pkl")
+        if not os.path.isdir(path):
+            raise ValueError(f"Error when saving a model - {path} is not a folder")
 
-        model_path, ext = os.path.splitext(model_path)
-        if ext == "":
-            ext += ".pkl"
-        model_path = model_path + ext
+        os.makedirs(path, exist_ok=True)
+        model_path = os.path.join(path, "model.pkl")
 
-        with open(pipeline_path, "wb") as f:
-            pickle.dump(self._pipeline, f)
         pipeline = self._pipeline
         del self._pipeline
         with open(model_path, "wb") as f:
             pickle.dump(self, f)
         self._pipeline = pipeline
+
+    def save_artifact(self, path: str, *args: Any, **kwargs: Any) -> None:
+        """
+        Saves sklearn pipeline
+
+        Parameters
+        ----------
+        path : str
+            the folder in which to save pipeline.pkl
+
+        Raises
+        ------
+        ValueError
+            if the path is not a valid directory
+        """
+        if not os.path.isdir(path):
+            raise ValueError(f"Error when saving an artifact - {path} is not a folder")
+
+        pipeline_path = os.path.join(path, "pipeline.pkl")
+        with open(pipeline_path, "wb") as f:
+            pickle.dump(self._pipeline, f)
+
+    def load_artifact(self, path: str, *args: Any, **kwargs: Any) -> None:
+        """
+        Loads sklearn pipeline
+
+        Parameters
+        ----------
+        path : str
+            the folder from which to load pipeline.pkl
+
+        Raises
+        ------
+        ValueError
+            if the path is not a valid directory
+        """
+        if not os.path.isdir(path):
+            raise ValueError(f"Error when loading an artifact - {path} is not a folder")
+
+        pipeline_path = os.path.join(path, "pipeline.pkl")
+        with open(pipeline_path, "wb") as f:
+            self._pipeline = pickle.load(f)
 
     def get_meta(self) -> PipeMeta:
         meta = super().get_meta()

--- a/cascade/utils/sklearn/sk_model.py
+++ b/cascade/utils/sklearn/sk_model.py
@@ -95,6 +95,7 @@ class SkModel(BasicModel):
             pickle.dump(self, f)
         self._pipeline = pipeline
 
+    # TODO: pass args to pickle
     def save_artifact(self, path: str, *args: Any, **kwargs: Any) -> None:
         """
         Saves sklearn pipeline
@@ -134,7 +135,7 @@ class SkModel(BasicModel):
             raise ValueError(f"Error when loading an artifact - {path} is not a folder")
 
         pipeline_path = os.path.join(path, "pipeline.pkl")
-        with open(pipeline_path, "wb") as f:
+        with open(pipeline_path, "rb") as f:
             self._pipeline = pickle.load(f)
 
     def get_meta(self) -> PipeMeta:

--- a/cascade/utils/tests/test_sk_model.py
+++ b/cascade/utils/tests/test_sk_model.py
@@ -60,11 +60,8 @@ def test_hash_check(tmp_path, ext):
         tree.load(os.path.join(tmp_path, "tree", "00000", "model"))
 
 
-@pytest.mark.parametrize("postfix", ["", "model", "model.pkl"])
-def test_save_load(tmp_path, postfix):
+def test_save_load(tmp_path):
     tmp_path = str(tmp_path)
-    if postfix:
-        tmp_path = os.path.join(tmp_path, postfix)
 
     model = SkModel(blocks=[RandomForestClassifier(n_estimators=2)], custom_param=42)
     model.save(tmp_path)
@@ -74,4 +71,17 @@ def test_save_load(tmp_path, postfix):
     model = SkModel.load(tmp_path)
 
     assert model.params.get("custom_param") == 42
+
+
+def test_model_artifacts(tmp_path):
+    tmp_path = str(tmp_path)
+
+    model = SkModel(blocks=[RandomForestClassifier(n_estimators=2)], custom_param=42)
+    model.save_artifact(tmp_path)
+
+    assert os.path.exists(os.path.join(tmp_path, "pipeline.pkl"))
+    assert not os.path.exists(os.path.join(tmp_path, "model.pkl"))
+
+    model = SkModel()
+    model.load_artifact(tmp_path)
     assert model._pipeline[0].n_estimators == 2

--- a/cascade/utils/tests/test_torch_model.py
+++ b/cascade/utils/tests/test_torch_model.py
@@ -29,12 +29,8 @@ sys.path.append(os.path.dirname(MODULE_PATH))
 from cascade.utils.torch import TorchModel
 
 
-@pytest.mark.parametrize("postfix", ["", "model", "model.pt"])
-def test_save_load(tmp_path, postfix):
+def test_save_load(tmp_path):
     tmp_path = str(tmp_path)
-
-    if postfix:
-        tmp_path = os.path.join(tmp_path, postfix)
 
     model = TorchModel(torch.nn.Linear, in_features=10, out_features=2)
 
@@ -44,6 +40,18 @@ def test_save_load(tmp_path, postfix):
 
     model = TorchModel.load(tmp_path)
 
-    assert str(model._model) == str(torch.nn.Linear(10, 2))
     assert model.params.get("in_features") == 10
     assert model.params.get("out_features") == 2
+
+
+def test_model_artifacts(tmp_path):
+    tmp_path = str(tmp_path)
+
+    model = TorchModel(torch.nn.Linear, in_features=10, out_features=2)
+
+    model.save_artifact(tmp_path)
+
+    model = TorchModel()
+    model.load_artifact(tmp_path)
+
+    assert str(model._model) == str(torch.nn.Linear(10, 2))

--- a/cascade/utils/torch/torch_model.py
+++ b/cascade/utils/torch/torch_model.py
@@ -21,10 +21,10 @@ from typing import Any, Type, Union
 import torch
 
 from ...base import PipeMeta
-from ...models import Model
+from ...models import BasicModel
 
 
-class TorchModel(Model):
+class TorchModel(BasicModel):
     """
     The wrapper around `nn.Module`s.
     """
@@ -58,6 +58,9 @@ class TorchModel(Model):
         Calls internal module with arguments provided.
         """
         return self._model(*args, **kwargs)
+
+    def evaluate(self, x: Any, y: Any, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError()
 
     def save(self, path: str, *args: Any, **kwargs: Any) -> None:
         """

--- a/cascade/utils/torch/torch_model.py
+++ b/cascade/utils/torch/torch_model.py
@@ -50,8 +50,7 @@ class TorchModel(Model):
             self._model = model
         elif model_class is not None:
             self._model = model_class(**kwargs)
-        else:
-            raise ValueError("Either `model_class` or `model` should be not None")
+
         super().__init__(**kwargs)
 
     def predict(self, *args, **kwargs) -> Any:
@@ -125,7 +124,7 @@ class TorchModel(Model):
             raise ValueError(f"Error when loading an artifact - {path} is not a folder")
 
         checkpoint_path = os.path.join(path, "checkpoint.pt")
-        with open(checkpoint_path, "wb") as f:
+        with open(checkpoint_path, "rb") as f:
             self._model = torch.load(f, *args, **kwargs)
 
     def get_meta(self) -> PipeMeta:


### PR DESCRIPTION
- Adds save_artifact/load_artifact method to each model to save standalone artifacts separately from cascade wrappers
- Model's save method now accepts only folders
- Regular save methods now save only wrappers, the same with load
- Adds ModelLine.load method that allows loading models with and without artifacts
- getitem now loads only wrappers
- Line saves models in the folders and to save artifacts creates `artifacts` folder inside of them
- Trainer was also updated accordingly

Important part of it is that those changes are breaking previous repo structure and loading models from old repos seems to be impossible since 0.13.0