### PR TITLE
Experiment sequences

### DIFF
--- a/cascade/base/traceable.py
+++ b/cascade/base/traceable.py
@@ -84,11 +84,14 @@ class Traceable:
 
             Meta is a list (see PipeMeta type alias) to allow the formation of pipelines.
         """
-        meta = {
-            "name": repr(self),
-            "description": self.description,
-            "tags": list(self.tags)
-        }
+        meta = {"name": repr(self)}
+
+        if hasattr(self, "description"):
+            meta["description"] = self.description
+
+        if hasattr(self, "description"):
+            meta["tags"] = list(self.tags)
+
         if hasattr(self, "_meta_prefix"):
             meta.update(self._meta_prefix)
         else:

--- a/cascade/models/model.py
+++ b/cascade/models/model.py
@@ -118,7 +118,7 @@ class Model(Traceable):
                 if but_its_ok:
                     continue
                 raise FileNotFoundError(
-                    f"File {filepath} not found when trying to copy an artifact of model {self.slug}"
+                    f"File {filepath} not found when trying to copy an artifact of model at {path}"
                 )
             filename = os.path.split(filepath)[-1]
 

--- a/cascade/models/model.py
+++ b/cascade/models/model.py
@@ -41,7 +41,6 @@ class Model(Traceable):
         log them in meta. Everything that is worth to document about model and data
         it was trained on can be put either in params or meta_prefix.
         """
-        self.slug = generate_slug()
         self.metrics = {}
         self.params = kwargs
         self.created_at = pendulum.now(tz="UTC")
@@ -148,7 +147,7 @@ class Model(Traceable):
         meta[0]["type"] = "model"
 
         all_default_exist = True
-        for attr in ("slug", "created_at", "metrics", "params"):
+        for attr in ("created_at", "metrics", "params"):
             if hasattr(self, attr):
                 meta[0][attr] = self.__getattribute__(attr)
             else:

--- a/cascade/models/model_line.py
+++ b/cascade/models/model_line.py
@@ -193,7 +193,8 @@ class ModelLine(TraceableOnDisk):
         model: Model
             Model to be saved
         only_meta: bool, optional
-            Flag, that indicates whether to save model's artifacts. If True saves only metadata and wrapper.
+            Flag, that indicates whether to save model's artifacts.
+            If True saves only metadata and wrapper.
         """
 
         if len(self.model_names) == 0:

--- a/cascade/models/model_line.py
+++ b/cascade/models/model_line.py
@@ -184,7 +184,7 @@ class ModelLine(TraceableOnDisk):
         using Model's method `save` in its own folder.
         Folder's name is assigned using f'{idx:0>5d}'. For example: 00001 or 00042.
 
-        It is Model's responsibility to correctly  assign extension and save its own state.
+        It is Model's responsibility to correctly assign extension and save its own state.
 
         Additionally, saves ModelLine's meta to the Line's root.
 
@@ -250,3 +250,12 @@ class ModelLine(TraceableOnDisk):
             }
         )
         return meta
+
+    def _save_only_meta(self, model: Model) -> None:
+        self.save(model, only_meta=True)
+
+    def add_model(self, *args: Any, **kwargs: Any) -> Any:
+        model = self._model_cls(*args, **kwargs)
+        model.add_log_callback(self._save_only_meta)
+        self.save(model, only_meta=True)
+        return model

--- a/cascade/models/model_repo.py
+++ b/cascade/models/model_repo.py
@@ -22,7 +22,6 @@ from ..base import (
     Traceable,
     TraceableOnDisk,
 )
-from ..base.utils import is_path
 from .model import Model
 from .model_line import ModelLine
 

--- a/cascade/models/trainer.py
+++ b/cascade/models/trainer.py
@@ -148,6 +148,10 @@ class BasicTrainer(Trainer):
                 raise RuntimeError(f"Cannot start from line {line_name} as it is empty")
             model, model_num = self._load_last_model(line)
 
+        # Since the model is created externally, we
+        # need to register a callback manually
+        model.add_log_callback(line._save_only_meta)
+
         start_time = pendulum.now()
         self._meta_prefix["train_start_at"] = start_time
         logger.info(f"Training started with parameters:\n{train_kwargs}")

--- a/cascade/models/trainer.py
+++ b/cascade/models/trainer.py
@@ -183,6 +183,7 @@ class BasicTrainer(Trainer):
             logger.info(f"Epoch {epoch}: {model.metrics}")
 
         end_time = pendulum.now()
+        # TODO: meta prefix can be str
         self._meta_prefix["train_end_at"] = end_time
         logger.info(
             f"Training finished in {end_time.diff_for_humans(start_time, True)}"

--- a/cascade/tests/test_model.py
+++ b/cascade/tests/test_model.py
@@ -55,3 +55,15 @@ def test_add_missing_file(tmp_path):
     model = Model()
     model.add_file("iammissingtoobutitsok.jpg", missing_ok=True)
     model.save(os.path.join(tmp_path, "model"))
+
+
+def test_add_callback():
+    def set_a_to_1(model):
+        model.a = 1
+
+    model = Model(a=0)
+    model.add_log_callback(set_a_to_1)
+    model.log_metrics({"acc": 0.0})
+
+    assert model.metrics["acc"] == 0.0
+    assert model.a == 1

--- a/cascade/tests/test_model_line.py
+++ b/cascade/tests/test_model_line.py
@@ -88,3 +88,15 @@ def test_load_model_meta(model_line, dummy_model):
     assert "metrics" in meta[0]
     assert "acc" in meta[0]["metrics"]
     assert slug == meta[0]["slug"]
+
+
+def test_add_model(tmp_path):
+    tmp_path = str(tmp_path)
+
+    line = ModelLine(tmp_path, model_cls=BasicModel)
+    model = line.add_model(a=0)
+    model.log_metrics({"b": 1})
+
+    assert model.params["a"] == 0
+    assert model.metrics["b"] == 1
+    assert len(line) == 2

--- a/cascade/tests/test_model_line.py
+++ b/cascade/tests/test_model_line.py
@@ -76,28 +76,15 @@ def test_same_index_check(model_line):
 
 
 #TODO: write tests for exceptions
-@pytest.mark.parametrize("arg", ["num", "slug"])
-def test_load_model_meta(model_line, dummy_model, arg):
-    slug = dummy_model.slug
+def test_load_model_meta(model_line, dummy_model):
     dummy_model.evaluate()
     model_line.save(dummy_model)
 
-    if arg == "num":
-        meta = model_line.load_model_meta(0)
-    elif arg == "slug":
-        meta = model_line.load_model_meta(slug)
-    else:
-        raise RuntimeError(arg)
+    with open(os.path.join(model_line.get_root(), "00000", "SLUG"), "r") as f:
+        slug = f.read()
+    meta = model_line.load_model_meta(slug)
 
     assert len(meta) == 1
     assert "metrics" in meta[0]
     assert "acc" in meta[0]["metrics"]
     assert slug == meta[0]["slug"]
-
-
-def test_cant_save_same_model_twice(model_line):
-    model = BasicModel()
-
-    model_line.save(model)
-    with pytest.raises(FileExistsError):
-        model_line.save(model)

--- a/cascade/tests/test_model_repo.py
+++ b/cascade/tests/test_model_repo.py
@@ -346,24 +346,20 @@ def test_change_of_format(tmp_path, ext):
 
 
 @pytest.mark.parametrize("ext", [".json", ".yml", ".yaml"])
-@pytest.mark.parametrize("arg", ["path", "slug"])
-def test_load_model_meta(tmp_path, dummy_model, arg, ext):
+def test_load_model_meta(tmp_path, dummy_model, ext):
     tmp_path = str(tmp_path)
     repo = ModelRepo(tmp_path, meta_fmt=ext)
     repo.add_line()
     repo.add_line()
     line = repo.add_line()
 
-    slug = dummy_model.slug
     dummy_model.evaluate()
     line.save(dummy_model)
 
-    if arg == "path":
-        meta = repo.load_model_meta("00002/00000")
-    elif arg == "slug":
-        meta = repo.load_model_meta(slug)
-    else:
-        raise RuntimeError(arg)
+    with open(os.path.join(line.get_root(), "00000", "SLUG"), "r") as f:
+        slug = f.read()
+
+    meta = repo.load_model_meta(slug)
 
     assert len(meta) == 1
     assert "metrics" in meta[0]

--- a/cascade/tests/test_workspace.py
+++ b/cascade/tests/test_workspace.py
@@ -50,8 +50,7 @@ def test_meta(tmp_path):
 
 
 @pytest.mark.parametrize("ext", [".json", ".yml", ".yaml"])
-@pytest.mark.parametrize("arg", ["path", "slug"])
-def test_load_model_meta(tmp_path, dummy_model, arg, ext):
+def test_load_model_meta(tmp_path, dummy_model, ext):
     tmp_path = str(tmp_path)
 
     for i in range(2):
@@ -64,16 +63,13 @@ def test_load_model_meta(tmp_path, dummy_model, arg, ext):
 
     wp = Workspace(tmp_path)
 
-    slug = dummy_model.slug
     dummy_model.evaluate()
     line.save(dummy_model)
 
-    if arg == "path":
-        meta = wp.load_model_meta("repo/00002/00000")
-    elif arg == "slug":
-        meta = wp.load_model_meta(slug)
-    else:
-        raise RuntimeError(arg)
+    with open(os.path.join(line.get_root(), "00000", "SLUG"), "r") as f:
+        slug = f.read()
+
+    meta = wp.load_model_meta(slug)
 
     assert len(meta) == 1
     assert "metrics" in meta[0]


### PR DESCRIPTION
You now can track metrics inside the model while the training loop is executed without calling `save`
This is done through the new method `log_metrics` which just updates `metrics` dictionaries if the model doesn't have any log callbacks. But if the model is created using new method `line.add_model` it is assigned a callback that will automatically save its metadata whenever the `log_metrics` is called.
This should also work in `Trainer`s - `BasicTrainer` will initialize a callback so you can use `log_metrics` inside `fit` method of a model.