### PR TITLE
Lazy Repo

### DIFF
--- a/cascade/base/__init__.py
+++ b/cascade/base/__init__.py
@@ -47,5 +47,5 @@ def raise_not_implemented(class_name: str, name: str) -> NoReturn:
 
 from .history_logger import HistoryLogger
 from .meta_handler import CustomEncoder as JSONEncoder
-from .meta_handler import MetaHandler, supported_meta_formats
+from .meta_handler import MetaHandler, default_meta_format, supported_meta_formats
 from .traceable import Traceable, TraceableOnDisk

--- a/cascade/base/meta_handler.py
+++ b/cascade/base/meta_handler.py
@@ -26,6 +26,7 @@ import numpy as np
 
 from . import MetaFromFile
 
+default_meta_format = ".json"
 supported_meta_formats = (".json", ".yml", ".yaml")
 
 

--- a/cascade/base/traceable.py
+++ b/cascade/base/traceable.py
@@ -272,17 +272,25 @@ class TraceableOnDisk(Traceable):
     ) -> None:
         super().__init__(*args, meta_prefix=meta_prefix, **kwargs)
         self._root = root
-        if meta_fmt not in supported_meta_formats:
-            raise ValueError(f"Only {supported_meta_formats} are supported formats")
-
+        
         ext = self._determine_meta_fmt()
-        if not ext or ext == meta_fmt:
+
+        if ext is None and meta_fmt is None:
+            meta_fmt = default_meta_format
+        elif not ext:
+            # Here we write meta first time and
+            # don't know the real ext from file
+            if meta_fmt not in supported_meta_formats:
+                raise ValueError(f"Only {supported_meta_formats} are supported formats")
             self._meta_fmt = meta_fmt
         else:
+            # Here we know the real extension and will
+            # strictly use it regardless of what was passed
             self._meta_fmt = ext
-            warnings.warn(
-                f"Trying to set {meta_fmt} to the object that already has {ext} on path {self._root}"
-            )
+            if meta_fmt != ext:
+                warnings.warn(
+                    f"Trying to set {meta_fmt} to the object that already has {ext} on path {self._root}"
+                )
 
     def _determine_meta_fmt(self) -> Union[str, None]:
         meta_paths = glob.glob(os.path.join(self._root, "meta.*"))

--- a/cascade/models/model_line.py
+++ b/cascade/models/model_line.py
@@ -36,7 +36,7 @@ class ModelLine(TraceableOnDisk):
         self,
         folder: str,
         model_cls: Type = Model,
-        meta_fmt: Literal[".json", ".yml", ".yaml"] = ".json",
+        meta_fmt: Literal[".json", ".yml", ".yaml", None] = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -49,7 +49,7 @@ class ModelLine(TraceableOnDisk):
             If folder does not exist, creates it
         model_cls: type, optional
             A class of models in line. ModelLine uses this class to reconstruct a model
-        meta_fmt: Literal[".json", ".yml", ".yaml"], optional
+        meta_fmt: Literal[".json", ".yml", ".yaml", None], optional
             Format in which to store meta data.
         See also
         --------

--- a/cascade/models/model_repo.py
+++ b/cascade/models/model_repo.py
@@ -241,7 +241,7 @@ class ModelRepo(Repo, TraceableOnDisk):
                 else self._model_cls[key],
             )
         else:
-            raise KeyError(f"Line {key} does not exist in {self._root}")
+            raise KeyError(f"Line {key} does not exist in {self}")
 
     def __repr__(self) -> str:
         return f"ModelRepo in {self._root} of {len(self)} lines"

--- a/cascade/tests/test_model_repo.py
+++ b/cascade/tests/test_model_repo.py
@@ -254,7 +254,7 @@ def test_failed_line_meta(tmp_path, ext):
         f.write("\t{{{: 'sorry, i am broken'")
 
     repo = ModelRepo(
-        repo_path, lines=[dict(name="0", model_cls=DummyModel, meta_fmt=ext)]
+        repo_path, lines=[dict(name="0", model_cls=DummyModel)], meta_fmt=ext
     )
     model = repo["0"][0]
 

--- a/cascade/tests/test_model_repo.py
+++ b/cascade/tests/test_model_repo.py
@@ -299,8 +299,8 @@ def test_integer_indices(tmp_path, ext):
     first_line = repo.add_line("a")
     last_line = repo.add_line("b")
 
-    assert first_line == repo[0]
-    assert last_line == repo[-1]
+    assert first_line.get_root() == repo[0].get_root()
+    assert last_line.get_root() == repo[-1].get_root()
 
 
 @pytest.mark.parametrize("ext", [".json", ".yml", ".yaml"])


### PR DESCRIPTION
This makes `ModelRepo` lazy in relation to the line creation - now it only stores names and line params passed in the constructor and creates only on `__getitem__`
The exception is the `add_line` method which records the arguments, creates and returns the line immediately 

The motivation to this change was to unify collections - `ModelLine` always was lazy, so it is the `Workspace`.