### PR TITLE
Metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,7 @@ from cascade import models as cdm
 from cascade import data as cdd
 
 model = cdm.Model()
-model.metrics.update({
-    'acc': random.random()
-})
+model.add_metric('acc': random.random())
 
 # Repo is the collection of model lines
 repo = cdm.ModelRepo('repos/use_case_repo')

--- a/cascade/base/meta_handler.py
+++ b/cascade/base/meta_handler.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 import os
 import json
+from dataclasses import asdict, is_dataclass
 import datetime
 from typing import NoReturn, Union, Dict, Any
 from json import JSONEncoder
@@ -76,6 +77,9 @@ class CustomEncoder(JSONEncoder):
 
         elif isinstance(obj, deepdiff.model.PrettyOrderedSet):
             return list(obj)
+
+        elif is_dataclass(obj):
+            return asdict(obj)
 
         return super(CustomEncoder, self).default(obj)
 

--- a/cascade/cli/cli.py
+++ b/cascade/cli/cli.py
@@ -65,7 +65,7 @@ def status(ctx):
         if ctx.obj.get("len"):
             output += f" of len {ctx.obj['len']}"
         click.echo(output)
-    
+
 
 @cli.command
 @click.pass_context
@@ -151,7 +151,7 @@ def metric(ctx, p, i, x):
         from ..models import ModelLine
         container = ModelLine(ctx.obj["cwd"])
     else:
-        click.echo(f"Cannot open History Viewer in object of type `{type}`")
+        click.echo(f"Cannot open Metric Viewer in object of type `{type}`")
         return
 
     from ..meta import MetricViewer

--- a/cascade/docs/source/examples/model_training.ipynb
+++ b/cascade/docs/source/examples/model_training.ipynb
@@ -229,7 +229,7 @@
     "        gt = torch.concat(gt).detach().numpy()\n",
     "\n",
     "        for metric_name in metrics_dict:\n",
-    "            self.metrics[metric_name] = metrics_dict[metric_name](gt, pred)"
+    "            self.add_metric(metric_name, metrics_dict[metric_name](gt, pred))"
    ]
   },
   {
@@ -899,7 +899,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.10.12"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/cascade/docs/source/index.rst
+++ b/cascade/docs/source/index.rst
@@ -50,7 +50,7 @@ along with all meta data.
 
     # Your existing experiment here
 
-    model.metrics.update({'f1': random.random()})
+    model.add_metric('f1', random.random())
 
     repo = ModelRepo('classification')
     line = repo.add_line('resnet')

--- a/cascade/meta/history_viewer.py
+++ b/cascade/meta/history_viewer.py
@@ -131,6 +131,7 @@ class HistoryViewer(Server):
                 new_meta = {"line": line_name, "model": i}
                 try:
                     meta = view[i][0]
+                    meta["metrics"] = {m["name"]: m["value"] for m in meta["metrics"]}
                     new_meta.update(flatten(meta))
                 except IndexError:
                     pass

--- a/cascade/meta/metric_viewer.py
+++ b/cascade/meta/metric_viewer.py
@@ -89,7 +89,7 @@ class MetricViewer:
                         ).diff_for_humans(metric["created_at"])
 
                 if "metrics" in meta:
-                    metric.update(meta["metrics"])
+                    metric.update({m["name"]: m["value"] for m in meta["metrics"]})
                 if "params" in meta:
                     metric.update(meta["params"])
 

--- a/cascade/models/__init__.py
+++ b/cascade/models/__init__.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 
 from .basic_model import BasicModel, BasicModelModifier
-from .metric import FnMetric, Metric
+from .metric import Metric
 from .model import Model, ModelModifier
 from .model_line import ModelLine
 from .model_repo import ModelRepo, Repo, SingleLineRepo

--- a/cascade/models/__init__.py
+++ b/cascade/models/__init__.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 from .basic_model import BasicModel, BasicModelModifier
+from .metric import FnMetric, Metric
 from .model import Model, ModelModifier
 from .model_line import ModelLine
 from .model_repo import ModelRepo, Repo, SingleLineRepo

--- a/cascade/models/metric.py
+++ b/cascade/models/metric.py
@@ -1,5 +1,8 @@
 from dataclasses import dataclass
-from typing import Union, Any, Literal, SupportsFloat, Tuple
+from typing import Union, Any, Literal, SupportsFloat, Tuple, Callable
+
+
+MetricType = SupportsFloat
 
 
 @dataclass
@@ -9,22 +12,31 @@ class Metric:
     and serves as the value and metadata storage
     """
     name: str
-    value: Union[SupportsFloat, None] = None
+    value: Union[MetricType, None] = None
     dataset: Union[str, None] = None
     split: Union[str, None] = None
     direction: Literal["up", "down", None] = None
-    interval: Union[Tuple[SupportsFloat, SupportsFloat], None] = None
+    interval: Union[Tuple[MetricType, MetricType], None] = None
 
-    def compute(self, *args: Any, **kwargs: Any) -> SupportsFloat:
+    def compute(self, *args: Any, **kwargs: Any) -> MetricType:
         """
         The method to compute metric's value. Should always populate
         the internal `self.value` field and return it.
         """
         raise NotImplementedError()
 
-    def compute_add(self, *args: Any, **kwargs: Any) -> SupportsFloat:
+    def compute_add(self, *args: Any, **kwargs: Any) -> MetricType:
         """
         The method to compute the metric incrementally.
         Should always populate the internal `self.value` field and return it.
         """
         raise NotImplementedError()
+
+
+class FnMetric(Metric):
+    def __init__(self, fn: Callable[[Any], MetricType], *args: Any, **kwargs: Any) -> None:
+        """
+        See cascade.models.Metric
+        """
+        super().__init__(*args, name=fn.__name__, **kwargs)
+        self.compute = fn

--- a/cascade/models/metric.py
+++ b/cascade/models/metric.py
@@ -1,6 +1,7 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Union, Any, Literal, SupportsFloat, Tuple
 
+import pendulum
 
 MetricType = SupportsFloat
 
@@ -11,12 +12,17 @@ class Metric:
     Base class for every metric, defines the way of computation
     and serves as the value and metadata storage
     """
+
     name: str
     value: Union[MetricType, None] = None
     dataset: Union[str, None] = None
     split: Union[str, None] = None
     direction: Literal["up", "down", None] = None
     interval: Union[Tuple[MetricType, MetricType], None] = None
+    created_at: str = field(init=False)
+
+    def __post_init__(self):
+        self.created_at = str(pendulum.now(tz="UTC"))
 
     def compute(self, *args: Any, **kwargs: Any) -> MetricType:
         """
@@ -34,12 +40,14 @@ class Metric:
 
     def __eq__(self, __value: object) -> bool:
         if isinstance(__value, Metric):
-            if (__value.name == self.name and
-                # Compare all fields without `value``
-                __value.dataset == self.dataset and
-                __value.split == self.split and
-                __value.direction == self.direction and
-                __value.interval == self.interval):
+            # Compare all fields without `value` and `created_at`
+            if (
+                __value.name == self.name
+                and __value.dataset == self.dataset
+                and __value.split == self.split
+                and __value.direction == self.direction
+                and __value.interval == self.interval
+            ):
                 return True
             return False
         return NotImplemented

--- a/cascade/models/metric.py
+++ b/cascade/models/metric.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Union, Any, Literal, SupportsFloat, Tuple, Callable
+from typing import Union, Any, Literal, SupportsFloat, Tuple
 
 
 MetricType = SupportsFloat
@@ -31,12 +31,3 @@ class Metric:
         Should always populate the internal `self.value` field and return it.
         """
         raise NotImplementedError()
-
-
-class FnMetric(Metric):
-    def __init__(self, fn: Callable[[Any], MetricType], *args: Any, **kwargs: Any) -> None:
-        """
-        See cascade.models.Metric
-        """
-        super().__init__(*args, name=fn.__name__, **kwargs)
-        self.compute = fn

--- a/cascade/models/metric.py
+++ b/cascade/models/metric.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+from typing import Union, Any, Literal, SupportsFloat, Tuple
+
+
+@dataclass
+class Metric:
+    """
+    Base class for every metric, defines the way of computation
+    and serves as the value and metadata storage
+    """
+    name: str
+    value: Union[SupportsFloat, None] = None
+    dataset: Union[str, None] = None
+    split: Union[str, None] = None
+    direction: Literal["up", "down", None] = None
+    interval: Union[Tuple[SupportsFloat, SupportsFloat], None] = None
+
+    def compute(self, *args: Any, **kwargs: Any) -> SupportsFloat:
+        """
+        The method to compute metric's value. Should always populate
+        the internal `self.value` field and return it.
+        """
+        raise NotImplementedError()
+
+    def compute_add(self, *args: Any, **kwargs: Any) -> SupportsFloat:
+        """
+        The method to compute the metric incrementally.
+        Should always populate the internal `self.value` field and return it.
+        """
+        raise NotImplementedError()

--- a/cascade/models/metric.py
+++ b/cascade/models/metric.py
@@ -31,3 +31,15 @@ class Metric:
         Should always populate the internal `self.value` field and return it.
         """
         raise NotImplementedError()
+
+    def __eq__(self, __value: object) -> bool:
+        if isinstance(__value, Metric):
+            if (__value.name == self.name and
+                # Compare all fields without `value``
+                __value.dataset == self.dataset and
+                __value.split == self.split and
+                __value.direction == self.direction and
+                __value.interval == self.interval):
+                return True
+            return False
+        return NotImplemented

--- a/cascade/models/model.py
+++ b/cascade/models/model.py
@@ -220,8 +220,8 @@ class Model(Traceable):
         if isinstance(metric, str):
             if value is None:
                 raise ValueError("value cannot be None if metric is str")
-                metric = Metric(name=metric,
-                       value=value, **kwargs)
+            metric = Metric(name=metric,
+                    value=value, **kwargs)
         elif isinstance(metric, Metric):
             if metric.value is None:
                 raise ValueError("metric.value cannot be None when adding")

--- a/cascade/models/model.py
+++ b/cascade/models/model.py
@@ -233,6 +233,8 @@ class Model(Traceable):
         for i, base_metric in enumerate(self.metrics):
             if metric == base_metric:
                 self.metrics[i] = metric
+                return
+
         self.metrics.append(metric)
 
 

--- a/cascade/models/model.py
+++ b/cascade/models/model.py
@@ -228,6 +228,10 @@ class Model(Traceable):
         else:
             raise TypeError(f"Metric can be either str or Metric type, not {type(metric)}")
 
+        # Model be initialized not properly
+        if not hasattr(self, "metrics"):
+            self.metrics = []
+
         # Overwrites metric if it is the same, but
         # value is different
         for i, base_metric in enumerate(self.metrics):

--- a/cascade/models/model.py
+++ b/cascade/models/model.py
@@ -199,7 +199,7 @@ class Model(Traceable):
     def add_metric(self, metric: Union[str, Metric],
                    value: Union[MetricType, None] = None, **kwargs: Any) -> None:
         """
-        Adds metric value to the model
+        Adds metric value to the model. If metric already exists in the list, updates its value.
 
         Parameters
         ----------
@@ -207,6 +207,8 @@ class Model(Traceable):
             Either metric name or metric object. If object, then second argument is ignored
         value : Union[MetricType, None], optional
             Metric value when metric is str, by default None
+
+        Any additional args will go to the Metric constructor for flexibility if metric is str
 
         Raises
         ------
@@ -218,16 +220,21 @@ class Model(Traceable):
         if isinstance(metric, str):
             if value is None:
                 raise ValueError("value cannot be None if metric is str")
-            self.metrics.append(
-                Metric(name=metric,
+                metric = Metric(name=metric,
                        value=value, **kwargs)
-            )
         elif isinstance(metric, Metric):
             if metric.value is None:
                 raise ValueError("metric.value cannot be None when adding")
-            self.metrics.append(metric)
         else:
             raise TypeError(f"Metric can be either str or Metric type, not {type(metric)}")
+        
+        # Overwrites metric if it is the same, but
+        # value is different
+        for i, base_metric in enumerate(self.metrics):
+            if metric == base_metric:
+                self.metrics[i] = metric
+        self.metrics.append(metric)
+
 
     def log(self) -> None:
         """

--- a/cascade/models/model.py
+++ b/cascade/models/model.py
@@ -66,7 +66,7 @@ class Model(Traceable):
 
     def evaluate(self, *args: Any, **kwargs: Any) -> None:
         """
-        Evaluates model against any metrics. Should not return any value, just populate self.metrics dict.
+        Evaluates model against any metrics. Should not return any value, just populate self.metrics
         """
         raise_not_implemented("cascade.models.Model", "evaluate")
 
@@ -227,7 +227,7 @@ class Model(Traceable):
                 raise ValueError("metric.value cannot be None when adding")
         else:
             raise TypeError(f"Metric can be either str or Metric type, not {type(metric)}")
-        
+
         # Overwrites metric if it is the same, but
         # value is different
         for i, base_metric in enumerate(self.metrics):

--- a/cascade/models/model_line.py
+++ b/cascade/models/model_line.py
@@ -288,5 +288,5 @@ class ModelLine(TraceableOnDisk):
         """
         model = self._model_cls(*args, **kwargs)
         model.add_log_callback(self._save_only_meta)
-        self.save(model, only_meta=True) # TODO: why?
+        # self.save(model, only_meta=True)
         return model

--- a/cascade/models/trainer.py
+++ b/cascade/models/trainer.py
@@ -174,7 +174,7 @@ class BasicTrainer(Trainer):
         for epoch in range(epochs):
             # Empty model's metrics to not to repeat them
             # in epochs where no evaluation
-            model.metrics = {}
+            model.metrics = []
 
             # Train model
             try:
@@ -202,7 +202,9 @@ class BasicTrainer(Trainer):
             # Record metrics:
             # no need to copy since don't reuse model's metrics dict
             self.metrics.append(model.metrics)
-            logger.info(f"Epoch {epoch}: {model.metrics}")
+            logger.info(f"Epoch: {epoch}")
+            for metric in model.metrics:
+                logger.info(metric)
 
         end_time = pendulum.now()
         self.train_end_at = end_time

--- a/cascade/tests/conftest.py
+++ b/cascade/tests/conftest.py
@@ -54,7 +54,7 @@ class DummyModel(BasicModel):
         pass
 
     def evaluate(self, *args, **kwargs):
-        self.metrics.update({"acc": np.random.random()})
+        self.add_metric("acc", np.random.random())
 
 
 class EmptyModel(DummyModel):

--- a/cascade/tests/conftest.py
+++ b/cascade/tests/conftest.py
@@ -70,11 +70,6 @@ class OnesModel(BasicModel):
         pass
 
 
-class ModelComplexMetric(BasicModel):
-    def predict(self, *args, **kwargs):
-        return None
-
-
 def f(x: int) -> int:
     return 2 * x
 

--- a/cascade/tests/test_basic_model.py
+++ b/cascade/tests/test_basic_model.py
@@ -50,8 +50,10 @@ def test_basic_model_with_concrete_case(ones_model):
         metrics_dict={"precision": precision, "recall": recall},
     )
 
-    assert model.metrics["precision"] == 2 / 3
-    assert model.metrics["recall"] == 1
+    assert model.metrics[0].name == "precision"
+    assert model.metrics[0].value == 2 / 3
+    assert model.metrics[0].name == "recall"
+    assert model.metrics[0].value == 1
 
 
 def test_modifier(ones_model):

--- a/cascade/tests/test_basic_model.py
+++ b/cascade/tests/test_basic_model.py
@@ -47,13 +47,13 @@ def test_basic_model_with_concrete_case(ones_model):
     model.evaluate(
         [random.randint(0, 255) for _ in range(3)],
         np.array([0, 1, 1]),
-        metrics_dict={"precision": precision, "recall": recall},
+        metrics=[precision, recall],
     )
 
     assert model.metrics[0].name == "precision"
     assert model.metrics[0].value == 2 / 3
-    assert model.metrics[0].name == "recall"
-    assert model.metrics[0].value == 1
+    assert model.metrics[1].name == "recall"
+    assert model.metrics[1].value == 1
 
 
 def test_modifier(ones_model):

--- a/cascade/tests/test_history_viewer.py
+++ b/cascade/tests/test_history_viewer.py
@@ -51,7 +51,7 @@ def test_no_metric(repo_or_line, dummy_model):
 
 def test_empty_model(model_repo, empty_model):
     model_repo.add_line("test", EmptyModel)
-    empty_model.metrics = {"acc": 0.9}
+    empty_model.add_metric("acc", 0.9)
     model_repo["test"].save(empty_model)
 
     hv = HistoryViewer(model_repo)

--- a/cascade/tests/test_metric_viewer.py
+++ b/cascade/tests/test_metric_viewer.py
@@ -90,26 +90,3 @@ def test_get_best_by(tmp_path, ext):
 
     mv = MetricViewer(repo)
     mv.get_best_by("acc")
-
-
-@pytest.mark.parametrize("ext", [".json", ".yml", ".yaml"])
-def test_get_best_by_non_sortable(tmp_path, ext):
-    repo = ModelRepo(str(tmp_path), meta_fmt=ext, model_cls=ModelComplexMetric)
-    line = repo.add_line("00001", model_cls=ModelComplexMetric)
-
-    for _ in range(10):
-        model = ModelComplexMetric()
-        model.evaluate(
-            None,
-            None,
-            {
-                "dict_metric": lambda x, y: {
-                    np.random.choice(["a", "b", "c"]): np.random.random()
-                }
-            },
-        )
-        line.save(model, only_meta=True)
-
-    mv = MetricViewer(repo)
-    with pytest.raises(TypeError):
-        mv.get_best_by("dict_metric")

--- a/cascade/tests/test_model.py
+++ b/cascade/tests/test_model.py
@@ -63,7 +63,8 @@ def test_add_callback():
 
     model = Model(a=0)
     model.add_log_callback(set_a_to_1)
-    model.log_metrics({"acc": 0.0})
+    model.add_metric("acc", 0.0)
+    model.log()
 
     assert model.metrics[0].name == "acc"
     assert model.metrics[0].value == 0.0

--- a/cascade/tests/test_model.py
+++ b/cascade/tests/test_model.py
@@ -65,5 +65,6 @@ def test_add_callback():
     model.add_log_callback(set_a_to_1)
     model.log_metrics({"acc": 0.0})
 
-    assert model.metrics["acc"] == 0.0
+    assert model.metrics[0].name == "acc"
+    assert model.metrics[0].value == 0.0
     assert model.a == 1

--- a/cascade/tests/test_model_line.py
+++ b/cascade/tests/test_model_line.py
@@ -87,7 +87,7 @@ def test_load_model_meta(model_line, dummy_model):
 
     assert len(meta) == 1
     assert "metrics" in meta[0]
-    assert "acc" in meta[0]["metrics"]
+    assert meta[0]["metrics"][0]["name"] == "acc"
     assert slug == meta[0]["slug"]
 
 
@@ -96,11 +96,13 @@ def test_add_model(tmp_path):
 
     line = ModelLine(tmp_path, model_cls=BasicModel)
     model = line.add_model(a=0)
-    model.log_metrics({"b": 1})
+    model.add_metric("b", 1)
+    model.log()
 
     assert model.params["a"] == 0
-    assert model.add_metric("b", 1)
-    assert len(line) == 2
+    assert model.metrics[0].name == "b"
+    assert model.metrics[0].value == 1
+    assert len(line) == 1 # Model is saved only on log()
 
 
 def test_handle_save_error(tmp_path):

--- a/cascade/tests/test_model_line.py
+++ b/cascade/tests/test_model_line.py
@@ -99,7 +99,7 @@ def test_add_model(tmp_path):
     model.log_metrics({"b": 1})
 
     assert model.params["a"] == 0
-    assert model.metrics["b"] == 1
+    assert model.add_metric("b", 1)
     assert len(line) == 2
 
 

--- a/cascade/tests/test_model_repo.py
+++ b/cascade/tests/test_model_repo.py
@@ -363,5 +363,5 @@ def test_load_model_meta(tmp_path, dummy_model, ext):
 
     assert len(meta) == 1
     assert "metrics" in meta[0]
-    assert "acc" in meta[0]["metrics"]
+    assert meta[0]["metrics"][0]["name"] == "acc"
     assert slug == meta[0]["slug"]

--- a/cascade/tests/test_workspace.py
+++ b/cascade/tests/test_workspace.py
@@ -73,5 +73,5 @@ def test_load_model_meta(tmp_path, dummy_model, ext):
 
     assert len(meta) == 1
     assert "metrics" in meta[0]
-    assert "acc" in meta[0]["metrics"]
+    assert meta[0]["metrics"][0]["name"] == "acc"
     assert slug == meta[0]["slug"]


### PR DESCRIPTION
## Standardizing metrics

The main change is that metrics are now scalars only. This should simplify internal metric processing and interfaces.
Metrics are now objects with a broad set of meta associated e.g. dataset, split (train, test), upper and lower bound for bootstrapping, direction (greater the better or less) etc.
Metric not only store values and meta, but can define ways of calculation using standard methods `compute` and `compute_add` for incremental computation.
Another thing that's changed is the `log_metric` method, which is now called `log` and does not record any metrics, but only saves the checkpoint by calling all the callbacks.


### This change is breaking
This change will affect any code that sets metrics the old way using dict:
```python
model.metrics.update({"acc": 0.85})
```

The easiest update for new style is:
```python
model.add_metric("acc", 0.85)
```
The aim was to make transition as simple as possible.