### PR TITLE
Unify container interface

### DIFF
--- a/cascade/base/utils.py
+++ b/cascade/base/utils.py
@@ -94,7 +94,7 @@ def migrate_repo_v0_13(path: str) -> None:
 
     for line in tqdm(repo.get_line_names(), desc=f"Migrating to {new_version}"):
         line_obj = ModelLine(os.path.join(repo.get_root(), line))
-        for model in line_obj.model_names:
+        for model in line_obj.get_model_names():
             try:
                 meta = MetaHandler.read_dir(os.path.join(path, line, model))
             except MetaIOError as e:

--- a/cascade/meta/metric_viewer.py
+++ b/cascade/meta/metric_viewer.py
@@ -73,7 +73,7 @@ class MetricViewer:
 
             view = MetaViewer(viewer_root, filt={"type": "model"})
 
-            for i in range(len(line.model_names)):
+            for i in range(len(line)):
                 try:
                     meta = view[i][-1]  # Takes last model from meta
                 except IndexError:

--- a/cascade/models/model_line.py
+++ b/cascade/models/model_line.py
@@ -60,7 +60,7 @@ class ModelLine(TraceableOnDisk):
         super().__init__(folder, meta_fmt, **kwargs)
         self._model_cls = model_cls
         self._root = os.path.abspath(folder)
-        self.model_names = []
+        self._model_names = []
         self._slug2name_cache = dict()
         if os.path.exists(self._root):
             self._load_model_names()

--- a/cascade/models/model_line.py
+++ b/cascade/models/model_line.py
@@ -14,10 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import glob
 import traceback
 import os
-from typing import Any, Literal, Type, Union
+from typing import Any, Literal, Type, Union, List
 
 import pendulum
 
@@ -60,7 +59,7 @@ class ModelLine(TraceableOnDisk):
         super().__init__(folder, meta_fmt, **kwargs)
         self._model_cls = model_cls
         self._root = folder
-        self.model_names = []
+        self._model_names = []
         self._slug2name_cache = dict()
         if os.path.exists(self._root):
             self._load_model_names()
@@ -74,7 +73,7 @@ class ModelLine(TraceableOnDisk):
         if not os.path.isdir(self._root):
             raise ValueError(f"folder should be directory, got `{self._root}`")
 
-        self.model_names = sorted(
+        self._model_names = sorted(
             [
                 model_folder
                 for model_folder in os.listdir(self._root)
@@ -104,7 +103,7 @@ class ModelLine(TraceableOnDisk):
         -------
         A number of models in line
         """
-        return len(self.model_names)
+        return len(self._model_names)
 
     def load(self, num: int, only_meta: bool = False) -> Model:
         """
@@ -117,10 +116,10 @@ class ModelLine(TraceableOnDisk):
         only_meta : bool, optional
             If True doesn't load model's artifacts, by default False
         """
-        model = self._model_cls.load(os.path.join(self._root, self.model_names[num]))
+        model = self._model_cls.load(os.path.join(self._root, self._model_names[num]))
         if not only_meta:
             model.load_artifact(
-                os.path.join(self._root, self.model_names[num], "artifacts")
+                os.path.join(self._root, self._model_names[num], "artifacts")
             )
 
         return model
@@ -136,7 +135,7 @@ class ModelLine(TraceableOnDisk):
         if slug in self._slug2name_cache:
             return self._slug2name_cache[slug]
 
-        for name in self.model_names:
+        for name in self._model_names:
             filepath = os.path.join(self._root, name, "SLUG")
             if not os.path.exists(filepath):
                 continue
@@ -203,10 +202,10 @@ class ModelLine(TraceableOnDisk):
             If True saves only metadata and wrapper.
         """
 
-        if len(self.model_names) == 0:
+        if len(self._model_names) == 0:
             idx = 0
         else:
-            idx = int(max(self.model_names)) + 1
+            idx = int(max(self._model_names)) + 1
 
         # Should check just in case
         while True:
@@ -259,7 +258,7 @@ class ModelLine(TraceableOnDisk):
         MetaHandler.write(
             os.path.join(full_path, "meta" + self._meta_fmt), meta
         )
-        self.model_names.append(folder_name)
+        self._model_names.append(folder_name)
         self._update_meta()
 
     def __repr__(self) -> str:
@@ -280,7 +279,7 @@ class ModelLine(TraceableOnDisk):
     def _save_only_meta(self, model: Model) -> None:
         self.save(model, only_meta=True)
 
-    def add_model(self, *args: Any, **kwargs: Any) -> Any:
+    def create_model(self, *args: Any, **kwargs: Any) -> Any:
         """
         Creates a model using the class given on
         creation, registers log callbacks for it
@@ -293,5 +292,15 @@ class ModelLine(TraceableOnDisk):
         """
         model = self._model_cls(*args, **kwargs)
         model.add_log_callback(self._save_only_meta)
-        # self.save(model, only_meta=True)
         return model
+
+    def get_model_names(self) -> List[str]:
+        """
+        Returns names of folders models live in
+
+        Returns
+        -------
+        List[str]
+            Only names of folders without whole path
+        """
+        return self._model_names

--- a/cascade/models/workspace.py
+++ b/cascade/models/workspace.py
@@ -124,3 +124,29 @@ class Workspace(TraceableOnDisk):
         raise FileNotFoundError(
             f"Failed to find the model {model} in the workspace at {self._root}"
         )
+
+    def add_repo(self, name: str, *args: Any, **kwargs: Any) -> ModelRepo:
+        """
+        Creates and adds repo to the Workspace
+
+        Parameters
+        ----------
+        name : str
+            Name of the repo
+
+        Returns
+        -------
+        ModelRepo
+            Created repo
+
+        Raises
+        ------
+        ValueError
+            If the repo already exists
+        """
+        if name in self._repo_names:
+            raise ValueError(f"Repo {name} already exists")
+
+        repo = ModelRepo(os.path.join(self._root, name), *args, **kwargs)
+        self._repo_names.append(name)
+        return repo

--- a/cascade/tests/test_model_line.py
+++ b/cascade/tests/test_model_line.py
@@ -103,11 +103,11 @@ def test_load_model_meta_num(model_line, dummy_model):
     assert meta[0]["metrics"][0]["value"] == dummy_model.metrics[0].value
 
 
-def test_add_model(tmp_path):
+def test_create_model(tmp_path):
     tmp_path = str(tmp_path)
 
     line = ModelLine(tmp_path, model_cls=BasicModel)
-    model = line.add_model(a=0)
+    model = line.create_model(a=0)
     model.add_metric("b", 1)
     model.log()
 

--- a/cascade/tests/test_model_line.py
+++ b/cascade/tests/test_model_line.py
@@ -153,4 +153,17 @@ def test_handle_save_artifact_error(tmp_path):
     assert "errors" in meta[0]
     assert "save_artifact" in meta[0]["errors"]
 
+
+def test_model_names(tmp_path):
+    tmp_path = str(tmp_path)
+
+    line = ModelLine(tmp_path)
+    model = line.create_model()
+
+    line.save(model)
+    line.save(model)
+    line.save(model)
+
+    assert line.get_model_names() == ["00000", "00001", "00002"]
+
 # TODO: write test for restoring line from repo

--- a/cascade/tests/test_model_line.py
+++ b/cascade/tests/test_model_line.py
@@ -166,4 +166,7 @@ def test_model_names(tmp_path):
 
     assert line.get_model_names() == ["00000", "00001", "00002"]
 
+    line = ModelLine(tmp_path)
+    assert line.get_model_names() == ["00000", "00001", "00002"]
+
 # TODO: write test for restoring line from repo

--- a/cascade/tests/test_workspace.py
+++ b/cascade/tests/test_workspace.py
@@ -87,3 +87,6 @@ def test_repo_names(tmp_path):
     wp.add_repo("2")
 
     assert wp.get_repo_names() == ["0", "1", "2"]
+
+    wp = Workspace(tmp_path)
+    assert wp.get_repo_names() == ["0", "1", "2"]

--- a/cascade/tests/test_workspace.py
+++ b/cascade/tests/test_workspace.py
@@ -75,3 +75,15 @@ def test_load_model_meta(tmp_path, dummy_model, ext):
     assert "metrics" in meta[0]
     assert meta[0]["metrics"][0]["name"] == "acc"
     assert slug == meta[0]["slug"]
+
+
+def test_repo_names(tmp_path):
+    tmp_path = str(tmp_path)
+
+    wp = Workspace(tmp_path)
+
+    wp.add_repo("0")
+    wp.add_repo("1")
+    wp.add_repo("2")
+
+    assert wp.get_repo_names() == ["0", "1", "2"]


### PR DESCRIPTION
- Adds `Workspace.add_repo` method in parallel with
- Changes `add_model` to `create_model`
- Removes public `ModelLine.model_names` property in favor of `ModelLine.get_model_names`