### PR TITLE
Sklearn metrics

### DIFF
--- a/cascade/utils/sklearn/__init__.py
+++ b/cascade/utils/sklearn/__init__.py
@@ -15,3 +15,4 @@ limitations under the License.
 """
 
 from .sk_model import SkModel
+from .sk_metric import SkMetric

--- a/cascade/utils/sklearn/sk_metric.py
+++ b/cascade/utils/sklearn/sk_metric.py
@@ -36,7 +36,10 @@ METRIC_ALIASES = {
 class SkMetric(Metric):
     def compute(self, *args: Any, **kwargs: Any) -> MetricType:
         try:
-            metric = getattr(metrics, self.name)
+            name = self.name
+            if self.name in METRIC_ALIASES:
+                name = METRIC_ALIASES[self.name]
+            metric = getattr(metrics, name)
         except AttributeError as e:
             raise AttributeError(
                 f"SkMetric accepts only names defined in module sklearn.metrics "

--- a/cascade/utils/sklearn/sk_metric.py
+++ b/cascade/utils/sklearn/sk_metric.py
@@ -46,4 +46,6 @@ class SkMetric(Metric):
                 f"as the list of aliases: {METRIC_ALIASES}"
             ) from e
 
-        return metric(*args, **kwargs)
+        value = metric(*args, **kwargs)
+        self.value = value
+        return value

--- a/cascade/utils/sklearn/sk_metric.py
+++ b/cascade/utils/sklearn/sk_metric.py
@@ -1,0 +1,46 @@
+"""
+Copyright 2022-2023 Ilia Moiseev
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import Any
+from sklearn import metrics
+
+from cascade.models.metric import MetricType
+
+from ...models import Metric
+
+
+METRIC_ALIASES = {
+    "acc": "accuracy_score",
+    "accuracy": "accuracy_score",
+    "precision": "precision_score",
+    "recall": "recall_score",
+    "f1": "f1_score",
+    "mse": "mean_squared_error",
+    "mae": "mean_absolute_error",
+}
+
+
+class SkMetric(Metric):
+    def compute(self, *args: Any, **kwargs: Any) -> MetricType:
+        try:
+            metric = getattr(metrics, self.name)
+        except AttributeError as e:
+            raise AttributeError(
+                f"SkMetric accepts only names defined in module sklearn.metrics "
+                f"as the list of aliases: {METRIC_ALIASES}"
+            ) from e
+
+        return metric(*args, **kwargs)

--- a/cascade/utils/tests/test_sk_metric.py
+++ b/cascade/utils/tests/test_sk_metric.py
@@ -1,0 +1,50 @@
+"""
+Copyright 2022-2023 Ilia Moiseev
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import os
+import shutil
+import sys
+
+import pytest
+from sklearn import metrics
+
+MODULE_PATH = os.path.dirname(
+    os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
+)
+sys.path.append(os.path.dirname(MODULE_PATH))
+
+from cascade.models import BasicModel
+from cascade.utils.sklearn import SkMetric
+
+
+def test(tmp_path):
+    tmp_path = str(tmp_path)
+
+    model = BasicModel()
+    model.predict = lambda x: [0 for _ in range(len(x))]
+
+    x = [None for _ in range(5)]
+    gt = [0, 0, 0, 1, 1]
+    model.evaluate(x, gt, metrics=[
+        SkMetric("acc"),
+        SkMetric("accuracy_score")
+    ])
+
+    assert model.metrics[0].value == 3 / 5
+    assert model.metrics[1].value == 3 / 5
+
+    pred = model.predict(x)
+    assert metrics.accuracy_score(gt, pred) == 3 / 5


### PR DESCRIPTION
Integrate new Metric objects with sklearn library seamlessly - you just need to write the name of the metric from `sklearn.metrics` module into the `cascade.utils.sklearn.SkMetric` object