### PR TITLE
Metrics as module

### DIFF
--- a/cascade/base/meta_handler.py
+++ b/cascade/base/meta_handler.py
@@ -29,6 +29,7 @@ import yaml
 import numpy as np
 
 from . import MetaFromFile, MetaIOError, ZeroMetaError, MultipleMetaError
+from ..metrics import Metric
 
 default_meta_format = ".json"
 supported_meta_formats = (".json", ".yml", ".yaml")
@@ -86,6 +87,9 @@ class CustomEncoder(JSONEncoder):
 
         elif is_dataclass(obj):
             return asdict(obj)
+
+        elif isinstance(obj, Metric):
+            return obj.to_dict()
 
         return super(CustomEncoder, self).default(obj)
 

--- a/cascade/base/utils.py
+++ b/cascade/base/utils.py
@@ -59,7 +59,8 @@ def migrate_repo_v0_13(path: str) -> None:
     """
     from tqdm import tqdm
     from cascade.base import MetaHandler, MetaIOError
-    from cascade.models import ModelRepo, ModelLine, Metric, MetricType, SingleLineRepo
+    from cascade.models import ModelRepo, ModelLine, SingleLineRepo
+    from cascade.metrics import Metric, MetricType
 
     def process_metrics(metrics: Dict[str, Any]) -> Tuple[List[Metric], Dict[str, Any]]:
         if not isinstance(metrics, dict):

--- a/cascade/metrics/__init__.py
+++ b/cascade/metrics/__init__.py
@@ -14,4 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from metric import Metric, MetricType
+from .metric import Metric, MetricType

--- a/cascade/metrics/__init__.py
+++ b/cascade/metrics/__init__.py
@@ -1,0 +1,17 @@
+"""
+Copyright 2022-2023 Ilia Moiseev
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from metric import Metric, MetricType

--- a/cascade/metrics/metric.py
+++ b/cascade/metrics/metric.py
@@ -14,25 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from dataclasses import dataclass, field
-from datetime import datetime
-from typing import Union, Any, Literal, SupportsFloat, Tuple
-
-from .base import Traceable
+from typing import Union, Any, Literal, SupportsFloat, Tuple, Dict
 
 import pendulum
 
 MetricType = SupportsFloat
 
 
-class Metric(Traceable):
+class Metric:
     """
     Base class for every metric, defines the way of computation
     and serves as the value and metadata storage
 
     Metrics should always be scalar. If your metric returns some
     complex types like dicts or lists consider using multiple
-    Metric objects.
+    Metric objects. Or if values are connected, use extra keyword.
     """
 
     def __init__(
@@ -44,6 +40,7 @@ class Metric(Traceable):
         split: Union[str, None] = None,
         direction: Literal["up", "down", None] = None,
         interval: Union[Tuple[MetricType, MetricType], None] = None,
+        extra: Union[Dict[str, MetricType], None] = None,
         **kwargs: Any
     ) -> None:
         self.name = name
@@ -53,6 +50,7 @@ class Metric(Traceable):
         self.direction = direction
         self.interval = interval
         self.created_at = pendulum.now(tz="UTC")
+        self.extra = extra
 
         super().__init__(*args, **kwargs)
 
@@ -83,3 +81,15 @@ class Metric(Traceable):
                 return True
             return False
         return NotImplemented
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "value": self.value,
+            "dataset": self.dataset,
+            "split": self.split,
+            "direction": self.direction,
+            "interval": self.interval,
+            "created_at": self.created_at,
+            "extra": self.extra,
+        }

--- a/cascade/metrics/metric.py
+++ b/cascade/metrics/metric.py
@@ -1,14 +1,31 @@
+"""
+Copyright 2022-2023 Ilia Moiseev
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Union, Any, Literal, SupportsFloat, Tuple
+
+from .base import Traceable
 
 import pendulum
 
 MetricType = SupportsFloat
 
 
-@dataclass
-class Metric:
+class Metric(Traceable):
     """
     Base class for every metric, defines the way of computation
     and serves as the value and metadata storage
@@ -18,16 +35,26 @@ class Metric:
     Metric objects.
     """
 
-    name: str
-    value: Union[MetricType, None] = None
-    dataset: Union[str, None] = None
-    split: Union[str, None] = None
-    direction: Literal["up", "down", None] = None
-    interval: Union[Tuple[MetricType, MetricType], None] = None
-    created_at: datetime = field(init=False)
-
-    def __post_init__(self):
+    def __init__(
+        self,
+        name: str,
+        *args: None,
+        value: Union[MetricType, None] = None,
+        dataset: Union[str, None] = None,
+        split: Union[str, None] = None,
+        direction: Literal["up", "down", None] = None,
+        interval: Union[Tuple[MetricType, MetricType], None] = None,
+        **kwargs: Any
+    ) -> None:
+        self.name = name
+        self.value = value
+        self.dataset = dataset
+        self.split = split
+        self.direction = direction
+        self.interval = interval
         self.created_at = pendulum.now(tz="UTC")
+
+        super().__init__(*args, **kwargs)
 
     def compute(self, *args: Any, **kwargs: Any) -> MetricType:
         """

--- a/cascade/models/__init__.py
+++ b/cascade/models/__init__.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 
 from .basic_model import BasicModel, BasicModelModifier
-from .metric import Metric, MetricType
 from .model import Model, ModelModifier
 from .model_line import ModelLine
 from .model_repo import ModelRepo, Repo, SingleLineRepo

--- a/cascade/models/metric.py
+++ b/cascade/models/metric.py
@@ -12,6 +12,10 @@ class Metric:
     """
     Base class for every metric, defines the way of computation
     and serves as the value and metadata storage
+
+    Metrics should always be scalar. If your metric returns some
+    complex types like dicts or lists consider using multiple
+    Metric objects.
     """
 
     name: str

--- a/cascade/models/model.py
+++ b/cascade/models/model.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, Union, Callable, Tuple
 
 import pendulum
 
-from .metric import MetricType, Metric
+from ..metrics import MetricType, Metric
 from ..base import PipeMeta, Traceable, raise_not_implemented
 
 

--- a/cascade/tests/metrics/test_metric.py
+++ b/cascade/tests/metrics/test_metric.py
@@ -1,0 +1,43 @@
+"""
+Copyright 2022-2023 Ilia Moiseev
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import os
+import sys
+
+# import pytest
+
+MODULE_PATH = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
+sys.path.append(os.path.dirname(MODULE_PATH))
+
+from cascade.base import MetaHandler
+from cascade.metrics import Metric
+
+
+def test_save_load(tmp_path_str):
+    metric = Metric(
+        name="acc",
+        value=0.48,
+        dataset="mnist",
+        split="train",
+        direction="up",
+        interval=(0.46, 0.50),
+        extra={"weighted_acc": 0.32}
+    )
+
+    MetaHandler.write(os.path.join(tmp_path_str, "metric.json"), metric)
+
+    from_file = MetaHandler.read(os.path.join(tmp_path_str, "metric.json"))
+    assert metric.to_dict() == from_file

--- a/cascade/utils/sklearn/sk_metric.py
+++ b/cascade/utils/sklearn/sk_metric.py
@@ -17,9 +17,7 @@ limitations under the License.
 from typing import Any
 from sklearn import metrics
 
-from cascade.models.metric import MetricType
-
-from ...models import Metric
+from ...metrics import MetricType, Metric
 
 
 METRIC_ALIASES = {


### PR DESCRIPTION
Metric should become more independent entity than simple dataclass with few methods so
- Moved in a separate module
- Do not inherit from anything - Traceable seems redundant
- Made more flexible to store more values if needed