### PR TITLE
Fix type diffs

### DIFF
--- a/cascade/base/history_handler.py
+++ b/cascade/base/history_handler.py
@@ -94,6 +94,11 @@ class HistoryHandler:
         obj: Any
             Meta data of the object
         """
+
+        # Use serialize nac back to prevent false diffs due to
+        # comparisons with meta from disk
+        obj = CustomEncoder().obj_to_dict(obj)
+
         if not self._log.get("latest"):
             self._log["latest"] = obj
         else:

--- a/cascade/tests/base/test_history_handler.py
+++ b/cascade/tests/base/test_history_handler.py
@@ -20,6 +20,7 @@ import pytest
 MODULE_PATH = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
 sys.path.append(os.path.dirname(MODULE_PATH))
 from cascade.base import HistoryHandler, MetaHandler
+from cascade.data import Wrapper, Modifier
 
 
 @pytest.mark.parametrize("ext", [".json", ".yml", ".yaml"])
@@ -49,9 +50,6 @@ def test_repo(tmp_path_str, ext):
 
 
 def test_get_state(tmp_path_str):
-    from cascade.base import HistoryHandler
-    from cascade.data import Wrapper, Modifier
-
     hl = HistoryHandler(os.path.join(tmp_path_str, "diff_history.yml"))
 
     ds = Wrapper([1, 2])
@@ -65,3 +63,28 @@ def test_get_state(tmp_path_str):
     assert hl.get(0) == meta1
     assert hl.get(1) == meta2
     assert len(hl) == 2
+
+
+@pytest.mark.parametrize("ext", [".json", ".yml", ".yaml"])
+def test_serialization_type_casts(tmp_path_str, ext):
+    """
+    Test that diff is zero although type changed while
+    serializing e.g. some field in meta was tuple, but
+    became list
+    """
+
+    hl = HistoryHandler(os.path.join(tmp_path_str, "diff_history" + ext))
+
+    ds = Wrapper([0, 1, 2])
+    ds.update_meta({"special_field": ("tuple", "that with become list")})
+
+    hl.log(ds.get_meta())
+    hl.log(ds.get_meta())
+    hl.log(ds.get_meta())
+
+    assert len(hl) == 1
+
+    hl = HistoryHandler(os.path.join(tmp_path_str, "diff_history" + ext))
+    hl.log(ds.get_meta())
+
+    assert len(hl) == 1


### PR DESCRIPTION
Fixes the problem with infinite history updates when no change was made. Changes were induced by serialization that caused type changes.