### PR TITLE
Improve meta prefix

### DIFF
--- a/cascade/base/traceable.py
+++ b/cascade/base/traceable.py
@@ -163,6 +163,9 @@ class Traceable:
         meta : Union[PipeMeta, Meta]
         """
         self.update_meta(meta)
+        
+        if not isinstance(meta, list):
+            meta = [meta]
 
         if "description" in meta[0]:
             self.describe(meta[0]["description"])

--- a/cascade/cli/cli.py
+++ b/cascade/cli/cli.py
@@ -172,7 +172,7 @@ def comment_add(ctx, c):
     from cascade.base import Traceable
 
     tr = Traceable()
-    tr.from_meta(ctx.obj["meta"][0])
+    tr.from_meta(ctx.obj["meta"])
     tr.comment(c)
     MetaHandler.write_dir(ctx.obj["cwd"], tr.get_meta())
 
@@ -202,7 +202,7 @@ def comment_rm(ctx, id):
     from cascade.base import Traceable
 
     tr = Traceable()
-    tr.from_meta(ctx.obj["meta"][0])
+    tr.from_meta(ctx.obj["meta"])
     tr.remove_comment(id)
     MetaHandler.write_dir(ctx.obj["cwd"], tr.get_meta())
 
@@ -226,7 +226,7 @@ def tag_add(ctx, t):
     from cascade.base import Traceable
 
     tr = Traceable()
-    tr.from_meta(ctx.obj["meta"][0])
+    tr.from_meta(ctx.obj["meta"])
     tr.tag(t)
     MetaHandler.write_dir(ctx.obj["cwd"], tr.get_meta())
 
@@ -251,7 +251,7 @@ def tag_rm(ctx, t):
     from cascade.base import Traceable
 
     tr = Traceable()
-    tr.from_meta(ctx.obj["meta"][0])
+    tr.from_meta(ctx.obj["meta"])
     tr.remove_tag(t)
     MetaHandler.write_dir(ctx.obj["cwd"], tr.get_meta())
 
@@ -308,7 +308,7 @@ def desc_add(ctx, d):
     from cascade.base import Traceable
 
     tr = Traceable()
-    tr.from_meta(ctx.obj["meta"][0])
+    tr.from_meta(ctx.obj["meta"])
     tr.describe(d)
     MetaHandler.write_dir(ctx.obj["cwd"], tr.get_meta())
 

--- a/cascade/data/composer.py
+++ b/cascade/data/composer.py
@@ -15,9 +15,9 @@ limitations under the License.
 """
 
 
-from typing import Any, List, Tuple
+from typing import Any, List, Tuple, Union
 
-from ..base import PipeMeta
+from ..base import PipeMeta, Meta
 from . import SizedDataset
 
 
@@ -72,3 +72,20 @@ class Composer(SizedDataset):
         meta = super().get_meta()
         meta[0]["data"] = [ds.get_meta() for ds in self._datasets]
         return meta
+
+    def from_meta(self, meta: Union[PipeMeta, Meta]) -> None:
+        """
+        Updates its own fields as usual and
+        if meta has `data` key then sequentially updates
+        data of all its datasets
+
+        Parameters
+        ----------
+        meta : Union[PipeMeta, Meta]
+            Meta of a single object or a pipeline
+        """
+
+        super().from_meta(meta)
+        if "data" in meta[0]:
+            for ds, meta in zip(self._datasets, meta[0]["data"]):
+                ds.from_meta(meta)

--- a/cascade/data/concatenator.py
+++ b/cascade/data/concatenator.py
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Any, List
+from typing import Any, List, Union
 
 import numpy as np
 
-from ..base import PipeMeta
+from ..base import Meta, PipeMeta
 from .dataset import SizedDataset, T
 
 
@@ -82,3 +82,20 @@ class Concatenator(SizedDataset):
         meta = super().get_meta()
         meta[0]["data"] = [ds.get_meta() for ds in self._datasets]
         return meta
+
+    def from_meta(self, meta: Union[PipeMeta, Meta]) -> None:
+        """
+        Updates its own fields as usual and
+        if meta has `data` key then sequentially updates
+        data of all its datasets
+
+        Parameters
+        ----------
+        meta : Union[PipeMeta, Meta]
+            Meta of a single object or a pipeline
+        """
+
+        super().from_meta(meta)
+        if "data" in meta[0]:
+            for ds, meta in zip(self._datasets, meta[0]["data"]):
+                ds.from_meta(meta)

--- a/cascade/data/dataset.py
+++ b/cascade/data/dataset.py
@@ -11,9 +11,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Any, Generic, Iterable, Sequence, Sized, TypeVar
+from typing import Any, Generic, Iterable, Sequence, Sized, TypeVar, Union
 
-from ..base import PipeMeta, Traceable, raise_not_implemented
+from ..base import Meta, PipeMeta, Traceable, raise_not_implemented
 
 T = TypeVar("T")
 
@@ -101,7 +101,67 @@ class Iterator(Dataset):
         return meta
 
 
-class ItModifier(Dataset):
+class BaseModifier(Dataset):
+    def __init__(self, dataset: SizedDataset[T], *args: Any, **kwargs: Any) -> None:
+        """
+        Constructs a Modifier. Makes no transformations in initialization.
+
+        Parameters
+        ----------
+        dataset: Dataset
+            A dataset to modify
+        """
+        self._dataset = dataset
+        super().__init__(*args, **kwargs)
+
+    def get_meta(self) -> PipeMeta:
+        """
+        Overrides base method enabling cascade-like calls to previous datasets.
+        The metadata of a pipeline that consist of several modifiers can be easily
+        obtained with `get_meta` of the last block.
+        """
+        self_meta = super().get_meta()
+        self_meta += self._dataset.get_meta()
+        return self_meta
+
+    def update_meta(self, meta: Union[PipeMeta, Meta]) -> None:
+        """
+        Overrides base method enabling cascade-like calls to previous datasets.
+        Updates its owm meta with the first entry and passes the rest to the
+        next dataset.
+
+        Parameters
+        ----------
+        meta : Union[PipeMeta, Meta]
+            Meta of a single object or a pipeline
+        """
+        if isinstance(meta, list):
+            super().update_meta(meta[0])
+            if len(meta) > 1:
+                self._dataset.update_meta(meta[1:])
+        else:
+            super().update_meta(meta)
+
+    def from_meta(self, meta: Union[PipeMeta, Meta]) -> None:
+        """
+        Calls the same method as base class but does
+        it cascade-like which allows to
+        roll list of meta on a pipeline
+
+        Parameters
+        ----------
+        meta : Union[PipeMeta, Meta]
+            Meta of a single object or a pipeline
+        """
+        if isinstance(meta, list):
+            super().from_meta(meta[0])
+            if len(meta) > 1:
+                self._dataset.from_meta(meta[1:])
+        else:
+            super().from_meta(meta)
+
+
+class ItModifier(BaseModifier):
     """
     The Modifier for Iterator datasets
 
@@ -109,9 +169,6 @@ class ItModifier(Dataset):
     --------
     cascade.data.Modifier
     """
-    def __init__(self, dataset: Iterator, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self._dataset = dataset
 
     def __iter__(self) -> Iterable[T]:
         for item in self._dataset:
@@ -149,7 +206,7 @@ class Wrapper(SizedDataset):
         return meta
 
 
-class Modifier(SizedDataset):
+class Modifier(BaseModifier):
     """
     Basic pipeline building block in Cascade. Every block which is not a data source should be
     a successor of Sampler or Modifier.
@@ -161,18 +218,6 @@ class Modifier(SizedDataset):
     Applies no transformation if `__getitem__` is not overridden.
     """
 
-    def __init__(self, dataset: SizedDataset[T], *args: Any, **kwargs: Any) -> None:
-        """
-        Constructs a Modifier. Makes no transformations in initialization.
-
-        Parameters
-        ----------
-        dataset: Dataset
-            A dataset to modify
-        """
-        self._dataset = dataset
-        super().__init__(*args, **kwargs)
-
     def __getitem__(self, index: Any) -> T:
         return self._dataset[index]
 
@@ -182,16 +227,11 @@ class Modifier(SizedDataset):
 
     def __len__(self) -> int:
         return len(self._dataset)
-
+    
     def get_meta(self) -> PipeMeta:
-        """
-        Overrides base method enabling cascade-like calls to previous datasets.
-        The metadata of a pipeline that consist of several modifiers can be easily
-        obtained with `get_meta` of the last block.
-        """
-        self_meta = super().get_meta()
-        self_meta += self._dataset.get_meta()
-        return self_meta
+        meta = super().get_meta()
+        meta[0]["len"] = len(self)
+        return meta
 
 
 class Sampler(Modifier):

--- a/cascade/data/dataset.py
+++ b/cascade/data/dataset.py
@@ -124,24 +124,6 @@ class BaseModifier(Dataset):
         self_meta += self._dataset.get_meta()
         return self_meta
 
-    def update_meta(self, meta: Union[PipeMeta, Meta]) -> None:
-        """
-        Overrides base method enabling cascade-like calls to previous datasets.
-        Updates its owm meta with the first entry and passes the rest to the
-        next dataset.
-
-        Parameters
-        ----------
-        meta : Union[PipeMeta, Meta]
-            Meta of a single object or a pipeline
-        """
-        if isinstance(meta, list):
-            super().update_meta(meta[0])
-            if len(meta) > 1:
-                self._dataset.update_meta(meta[1:])
-        else:
-            super().update_meta(meta)
-
     def from_meta(self, meta: Union[PipeMeta, Meta]) -> None:
         """
         Calls the same method as base class but does

--- a/cascade/tests/base/test_traceable.py
+++ b/cascade/tests/base/test_traceable.py
@@ -50,6 +50,8 @@ def test_update_meta():
     assert meta[0]["b"] == 3
 
 
+# This is deprecated since 0.13.0
+@pytest.mark.skip
 def test_meta_from_file(tmp_path):
     with open(os.path.join(tmp_path, "test_meta_from_file.json"), "w") as f:
         json.dump({"a": 1}, f)
@@ -61,6 +63,8 @@ def test_meta_from_file(tmp_path):
     assert meta[0]["a"] == 1
 
 
+# This is deprecated since 0.13.0
+@pytest.mark.skip
 def test_update_meta_from_file(tmp_path):
     with open(os.path.join(tmp_path, "test_meta_from_file.json"), "w") as f:
         json.dump({"a": 1}, f)
@@ -193,6 +197,7 @@ def test_links():
 
 def test_from_meta():
     tr = Traceable()
+    tr.update_meta({"a": 1})
     tr.tag("tag")
     tr.describe("description")
     tr.comment("lol")
@@ -201,8 +206,9 @@ def test_from_meta():
     meta = tr.get_meta()
 
     tr = Traceable()
-    tr.from_meta(meta[0])
+    tr.from_meta(meta)
 
+    assert tr.get_meta()[0]["a"] == 1
     assert tr.tags == set(["tag"])
     assert tr.description == "description"
     assert [c.message for c in tr.comments] == ["lol", "kek"]

--- a/cascade/tests/data/test_composer.py
+++ b/cascade/tests/data/test_composer.py
@@ -29,8 +29,7 @@ def test_meta():
     n1 = Wrapper([0, 1, 2, 3])
     n2 = Wrapper([2, 3, 4, 5])
 
-    c = Composer([n1, n2], meta_prefix={"num": 1})
-    assert c.get_meta()[0]["num"] == 1
+    c = Composer([n1, n2])
     assert len(c.get_meta()[0]["data"]) == 2
 
 

--- a/cascade/tests/data/test_composer.py
+++ b/cascade/tests/data/test_composer.py
@@ -33,6 +33,28 @@ def test_meta():
     assert len(c.get_meta()[0]["data"]) == 2
 
 
+def test_from_meta():
+    n1 = Wrapper([0, 1, 2, 3])
+    n2 = Wrapper([0, 1, 2, 3])
+
+    n1.update_meta({"a": 1})
+    n2.update_meta({"b": 0})
+
+    c = Composer([n1, n2])
+    meta = c.get_meta()
+
+    n1 = Wrapper([0, 1, 2, 3])
+    n2 = Wrapper([0, 1, 2, 3])
+
+    c = Composer([n1, n2])
+    c.from_meta(meta)
+
+    meta = c.get_meta()
+
+    assert meta[0]["data"][0][0]["a"] == 1
+    assert meta[0]["data"][1][0]["b"] == 0
+
+
 @pytest.mark.parametrize(
     "datasets",
     [

--- a/cascade/tests/data/test_concatenator.py
+++ b/cascade/tests/data/test_concatenator.py
@@ -33,6 +33,28 @@ def test_meta():
     assert len(c.get_meta()[0]["data"]) == 2
 
 
+def test_from_meta():
+    n1 = Wrapper([0, 1, 2, 3])
+    n2 = Wrapper([0, 1, 2, 3])
+
+    n1.update_meta({"a": 1})
+    n2.update_meta({"b": 0})
+
+    c = Concatenator([n1, n2])
+    meta = c.get_meta()
+
+    n1 = Wrapper([0, 1, 2, 3])
+    n2 = Wrapper([0, 1, 2, 3])
+
+    c = Concatenator([n1, n2])
+    c.from_meta(meta)
+
+    meta = c.get_meta()
+
+    assert meta[0]["data"][0][0]["a"] == 1
+    assert meta[0]["data"][1][0]["b"] == 0
+
+
 @pytest.mark.parametrize(
     "arrs",
     [

--- a/cascade/tests/data/test_concatenator.py
+++ b/cascade/tests/data/test_concatenator.py
@@ -29,8 +29,7 @@ def test_meta():
     n1 = Wrapper([0, 1])
     n2 = Wrapper([2, 3, 4, 5])
 
-    c = Concatenator([n1, n2], meta_prefix={"num": 1})
-    assert c.get_meta()[0]["num"] == 1
+    c = Concatenator([n1, n2])
     assert len(c.get_meta()[0]["data"]) == 2
 
 

--- a/cascade/tests/data/test_dataset.py
+++ b/cascade/tests/data/test_dataset.py
@@ -109,6 +109,34 @@ def test_modifier_meta():
     assert len(meta) == 2
 
 
+def test_modifier_update_meta():
+    ds = Wrapper([1 ,2 ,3])
+    ds = Modifier(ds)
+    ds.update_meta([
+        {"a": 1}, {"b": 0}
+    ])
+
+    meta = ds.get_meta()
+    assert meta[0]["a"] == 1
+    assert meta[1]["b"] == 0
+
+
+def test_modifier_from_meta():
+    ds = Wrapper([1 ,2 ,3])
+    ds = Modifier(ds)
+    ds.update_meta([
+        {"a": 1}, {"b": 0}
+    ])
+    meta = ds.get_meta()
+
+    ds = Wrapper([1 ,2 ,3])
+    ds = Modifier(ds)
+    ds.from_meta(meta)
+
+    assert meta[0]["a"] == 1
+    assert meta[1]["b"] == 0
+
+
 def test_sampler():
     ds = Wrapper([1, 2, 3, 4])
     ds = Sampler(ds, 10)

--- a/cascade/tests/data/test_dataset.py
+++ b/cascade/tests/data/test_dataset.py
@@ -35,7 +35,8 @@ def test_getitem():
 
 def test_meta():
     now = datetime.datetime.now()
-    ds = Dataset(meta_prefix={"time": now})
+    ds = Dataset()
+    ds.update_meta({"time": now})
     meta = ds.get_meta()
 
     assert type(meta) == list
@@ -46,7 +47,8 @@ def test_meta():
 
 
 def test_update_meta():
-    ds = Dataset(meta_prefix={"a": 1, "b": 2})
+    ds = Dataset()
+    ds.update_meta({"a": 1, "b": 2})
     ds.update_meta({"b": 3})
     meta = ds.get_meta()
 
@@ -54,6 +56,8 @@ def test_update_meta():
     assert meta[0]["b"] == 3
 
 
+# This is deprecated since 0.13.0
+@pytest.mark.skip
 def test_meta_from_file(tmp_path):
     with open(os.path.join(tmp_path, "test_meta_from_file.json"), "w") as f:
         json.dump({"a": 1}, f)


### PR DESCRIPTION
This PR brings breaking changes into `0.13.0`
- `meta_prefix` is removed from any `Traceable` `__init__`s - now it can only be updated using `update_meta()` method
- `update_meta` and `from_meta` can now accept lists - for common traceables those are just meta lists with unit length
- `Modifier`s and other entities that form pipelines now can restore meta using `from_meta` for the whole pipelines