### PR TITLE
Versioning

### DIFF
--- a/cascade/data/__init__.py
+++ b/cascade/data/__init__.py
@@ -28,4 +28,4 @@ from .range_sampler import RangeSampler
 from .sequential_cacher import SequentialCacher
 from .simple_dataloader import SimpleDataloader
 from .utils import split
-from .version_assigner import VersionAssigner
+from .version_assigner import VersionAssigner, version

--- a/cascade/data/version_assigner.py
+++ b/cascade/data/version_assigner.py
@@ -189,3 +189,28 @@ class VersionAssigner(Modifier):
         meta = super().get_meta()
         meta[0]["version"] = self.version
         return meta
+
+
+def version(ds: Dataset[T], path: str) -> str:
+    """
+    Returns version of a dataset using VersionAssigner
+
+    Parameters
+    ----------
+    ds : Dataset[T]
+        Dataset to track and version
+    path : str
+        Path to the version log of a dataset, will be created if does
+        not exists
+
+    Returns
+    -------
+    str
+        Version in two parts like 2.1 or 0.1
+
+    See also
+    --------
+    cascade.data.VersionAssigner
+    """
+    ds = VersionAssigner(ds, path)
+    return ds.version

--- a/cascade/tests/data/test_version_assigner.py
+++ b/cascade/tests/data/test_version_assigner.py
@@ -22,7 +22,7 @@ import pytest
 MODULE_PATH = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
 sys.path.append(os.path.dirname(MODULE_PATH))
 
-from cascade.data import ApplyModifier, Concatenator, VersionAssigner, Wrapper
+from cascade.data import ApplyModifier, Concatenator, VersionAssigner, Wrapper, version
 
 
 @pytest.mark.parametrize("ext", [".json", ".yml", ".yaml"])
@@ -68,3 +68,25 @@ def test_deep_changes(tmp_path, ext):
     ds = VersionAssigner(ds, filepath)
 
     assert ds.version == "1.0"
+
+
+@pytest.mark.parametrize("ext", [".json", ".yml", ".yaml"])
+def test_function(tmp_path, ext):
+    filepath = os.path.join(tmp_path, "ds" + ext)
+
+    ds = Wrapper([0, 1, 2, 3, 4])
+    ds = ApplyModifier(ds, lambda x: x * 2)
+    ds = Concatenator([ds, ds])
+    ds = Concatenator([ds, ds])
+    ver = version(ds, filepath)
+
+    assert ver == "0.0"
+
+    ds = Wrapper([0, 1, 2, 3, 4])
+    ds = ApplyModifier(ds, lambda x: x * 2)
+    ds = ApplyModifier(ds, lambda x: x * 2)
+    ds = Concatenator([ds, ds])
+    ds = Concatenator([ds, ds])
+    ver = version(ds, filepath)
+
+    assert ver == "1.0"

--- a/cascade/tests/data/test_version_assigner.py
+++ b/cascade/tests/data/test_version_assigner.py
@@ -49,6 +49,18 @@ def test(tmp_path, ext):
 
 
 @pytest.mark.parametrize("ext", [".json", ".yml", ".yaml"])
+def test_idempotency(tmp_path, ext):
+    filepath = os.path.join(tmp_path, "ds" + ext)
+
+    ds = Wrapper([0, 1, 2, 3, 4])
+    va = VersionAssigner(ds, filepath)
+    assert va.version == "0.0"
+
+    va = VersionAssigner(ds, filepath)
+    assert va.version == "0.0"
+
+
+@pytest.mark.parametrize("ext", [".json", ".yml", ".yaml"])
 def test_deep_changes(tmp_path, ext):
     filepath = os.path.join(tmp_path, "ds" + ext)
 


### PR DESCRIPTION
More convenient interface for version logging is a function so 'cascade.data.version()' function added