### PR TITLE
Raise exceptions in data registrator as warnings by default

### DIFF
--- a/cascade/base/history_handler.py
+++ b/cascade/base/history_handler.py
@@ -93,6 +93,10 @@ class HistoryHandler:
         ----------
         obj: Any
             Meta data of the object
+        
+        Raises
+        ------
+        MetaIOError - if log writing fails
         """
 
         # Use serialize nac back to prevent false diffs due to

--- a/cascade/meta/data_registrator.py
+++ b/cascade/meta/data_registrator.py
@@ -16,10 +16,11 @@ limitations under the License.
 
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Tuple, Union
+import warnings
 
 import pendulum
 
-from ..base import HistoryHandler
+from ..base import HistoryHandler, MetaIOError
 
 
 @dataclass
@@ -146,8 +147,24 @@ class DataRegistrator:
     has some properties changed during the time.
     """
 
-    def __init__(self, filepath: str) -> None:
-        self._logger = HistoryHandler(filepath)
+    def __init__(self, filepath: str, raise_on_fail: bool = False) -> None:
+        """
+        Parameters
+        ----------
+        filepath : str
+            Path to the log file for HistoryLogger
+        raise_on_fail : bool, optional
+            Whether to raise a warning or an exception in case when
+            logger failed to read a file for some reason, by default False
+        """
+        self._raise_on_fail = raise_on_fail
+        try:
+            self._logger = HistoryHandler(filepath)
+        except MetaIOError as e:
+            if self._raise_on_fail:
+                raise e
+            else:
+                warnings.warn(str(e))
 
     def register(self, card: DataCard) -> None:
         """
@@ -170,4 +187,10 @@ class DataRegistrator:
         now = str(pendulum.now(tz="UTC"))
         card.data["updated_at"] = now
 
-        self._logger.log(card.data)
+        try:
+            self._logger.log(card.data)
+        except MetaIOError as e:
+            if self._raise_on_fail:
+                raise e
+            else:
+                warnings.warn(str(e))


### PR DESCRIPTION
Some pipelines may fail only if the log was incorrectly written. This should not be the case