### PR TITLE
Allow batch size being bigger than sequence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 #python
 __pycache__/
+venv
 
 #cascade
 .cascade/

--- a/cascade/data/simple_dataloader.py
+++ b/cascade/data/simple_dataloader.py
@@ -36,8 +36,7 @@ class SimpleDataloader:
         if batch_size == 0:
             raise ValueError("Batch size cannot be 0")
         if batch_size > len(data):
-            raise ValueError(
-                f"Batch size ({batch_size}) is larger than sequence length ({len(data)})")
+            batch_size = len(data)
 
         self._data = data
         self._bs = batch_size

--- a/cascade/tests/data/test_simple_dataloader.py
+++ b/cascade/tests/data/test_simple_dataloader.py
@@ -19,7 +19,6 @@ import sys
 
 import pytest
 
-
 SCRIPT_DIR = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
 sys.path.append(os.path.dirname(SCRIPT_DIR))
 
@@ -46,9 +45,20 @@ def test_batches(arr, bs, result):
     "arr, bs",
     [
         ([1], 0),
-        ([1], 2),
     ],
 )
 def test_illegal(arr, bs):
     with pytest.raises(ValueError):
         dl = SimpleDataloader(arr, batch_size=bs)
+
+
+@pytest.mark.parametrize(
+    "arr, bs",
+    [
+        ([1], 2),
+        ([1, 2], 1000),
+    ],
+)
+def test_larger_than_sequence(arr, bs):
+    dl = SimpleDataloader(arr, batch_size=bs)
+    assert list(dl) == [arr]


### PR DESCRIPTION
This annoying error caused a lot of pain for me personally. It is so simple and yet lots of pipelines were broken because of this. I don't see any issue with setting batch size to the length of the sequence if the sequence happens to be smaller than a single batch.