### PR TITLE
Viewer fixes

### DIFF
--- a/cascade/cli/cli.py
+++ b/cascade/cli/cli.py
@@ -126,10 +126,12 @@ def view_history(ctx, host, port, l, m, p):  # noqa: E741
 
 @view.command("metric")
 @click.pass_context
+@click.option("--host", type=str, default="localhost")
+@click.option("--port", type=int, default=8050)
 @click.option("-p", type=int, default=50, help="Page size for table")
 @click.option("-i", type=str, multiple=True, help="Metrics or params to include")
 @click.option("-x", type=str, multiple=True, help="Metrics or params to exclude")
-def view_metric(ctx, p, i, x):
+def view_metric(ctx, host, port, p, i, x):
     type = ctx.obj["type"]
     if type == "repo":
         from ..models import ModelRepo
@@ -144,14 +146,16 @@ def view_metric(ctx, p, i, x):
     from ..meta import MetricViewer
     i = None if len(i) == 0 else list(i)
     x = None if len(x) == 0 else list(x)
-    MetricViewer(container).serve(page_size=p, include=i, exclude=x)
+    MetricViewer(container).serve(page_size=p, include=i, exclude=x, host=host, port=port)
 
 
 @view.command("diff")
 @click.pass_context
-def view_diff(ctx):
+@click.option("--host", type=str, default="localhost")
+@click.option("--port", type=int, default=8050)
+def view_diff(ctx, host, port):
     from ..meta import DiffViewer
-    DiffViewer(ctx.obj["cwd"]).serve()
+    DiffViewer(ctx.obj["cwd"]).serve(host=host, port=port)
 
 
 @cli.group

--- a/cascade/meta/metric_viewer.py
+++ b/cascade/meta/metric_viewer.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 
 import os
-from typing import Any, List, Union
+from typing import Any, Dict, List, Union
 
 import pandas as pd
 import pendulum
@@ -68,6 +68,26 @@ class MetricViewer:
         return MetricViewer(self._repo, scope=key)
 
     def reload_table(self) -> None:
+        def create_metric(meta: Dict[str, Any]) -> Dict[str, Any]:
+            metric = {"line": line, "num": i}
+            if "created_at" in meta:
+                metric["created_at"] = pendulum.parse(meta["created_at"])
+                if "saved_at" in meta:
+                    metric["saved"] = pendulum.parse(
+                        meta["saved_at"]
+                    ).diff_for_humans(metric["created_at"])
+
+            if "params" in meta:
+                metric.update(meta["params"])
+            if "tags" in meta:
+                metric["tags"] = meta["tags"]
+            if "comments" in meta:
+                metric["comment_count"] = len(meta["comments"])
+            if "links" in meta:
+                metric["link_count"] = len(meta["links"])
+            
+            return metric
+
         self._metrics = []
         selected_names = self._repo.get_line_names()
 
@@ -92,23 +112,7 @@ class MetricViewer:
                 if "metrics" in meta:
                     # Need to generate new metric each time
                     for m in meta["metrics"]:
-                        metric = {"line": line, "num": i}
-
-                        if "created_at" in meta:
-                            metric["created_at"] = pendulum.parse(meta["created_at"])
-                            if "saved_at" in meta:
-                                metric["saved"] = pendulum.parse(
-                                    meta["saved_at"]
-                                ).diff_for_humans(metric["created_at"])
-
-                        if "params" in meta:
-                            metric.update(meta["params"])
-                        if "tags" in meta:
-                            metric["tags"] = meta["tags"]
-                        if "comments" in meta:
-                            metric["comment_count"] = len(meta["comments"])
-                        if "links" in meta:
-                            metric["link_count"] = len(meta["links"])
+                        metric = create_metric(meta)
 
                         metric["name"] = m.get("name")
                         metric["value"] =  m.get("value")
@@ -120,7 +124,7 @@ class MetricViewer:
 
                         self._metrics.append(metric)
                 else:
-                    self._metrics.append({"line": line, "num": i})
+                    self._metrics.append(create_metric(meta))
         self.table = pd.DataFrame(self._metrics)
 
     def __repr__(self) -> str:

--- a/cascade/meta/metric_viewer.py
+++ b/cascade/meta/metric_viewer.py
@@ -265,7 +265,10 @@ class MetricServer(Server):
         if self._include is not None:
             df = df[["line", "num"] + self._include]
 
-        self._df_flatten = pd.DataFrame(map(flatten, df.to_dict("records")))
+        self._df_flatten = pd.DataFrame(
+            map(lambda x: flatten(x, root_keys_to_ignore=["tags"]), df.to_dict("records"))
+        )
+        self._df_flatten["tags"] = df["tags"].apply(lambda x: ",".join(x))
         dep_fig = go.Figure()
 
         return html.Div(

--- a/cascade/meta/metric_viewer.py
+++ b/cascade/meta/metric_viewer.py
@@ -98,8 +98,6 @@ class MetricViewer:
                             meta["saved_at"]
                         ).diff_for_humans(metric["created_at"])
 
-                if "metrics" in meta:
-                    metric.update({m["name"]: m.get("value") for m in meta["metrics"]})
                 if "params" in meta:
                     metric.update(meta["params"])
                 if "tags" in meta:
@@ -108,8 +106,17 @@ class MetricViewer:
                     metric["comment_count"] = len(meta["comments"])
                 if "links" in meta:
                     metric["link_count"] = len(meta["links"])
+                if "metrics" in meta:
+                    for m in meta["metrics"]:
+                        metric[m["name"]] = m.get("value")
+                        for key in m.keys():
+                            if key not in ("name", "value", "created_at"):
+                                if m[key] is not None:
+                                    metric[key] = m[key]
 
-                self._metrics.append(metric)
+                        self._metrics.append(metric)
+                else:
+                    self._metrics.append(metric)
         self.table = pd.DataFrame(self._metrics)
 
     def __repr__(self) -> str:

--- a/cascade/meta/metric_viewer.py
+++ b/cascade/meta/metric_viewer.py
@@ -283,7 +283,7 @@ class MetricServer(Server):
         self._df_flatten = pd.DataFrame(
             map(lambda x: flatten(x, root_keys_to_ignore=["tags"]), df.to_dict("records"))
         )
-        self._for_plots = self._df_flatten
+        self._for_plots = self._df_flatten.copy()
         for name in self._df_flatten.name.unique():
             self._for_plots[name] = None
             self._for_plots.loc[self._for_plots["name"] == name, name] = (

--- a/cascade/meta/metric_viewer.py
+++ b/cascade/meta/metric_viewer.py
@@ -89,26 +89,30 @@ class MetricViewer:
                     meta = {}
 
                 _, line = os.path.split(viewer_root)
-                metric = {"line": line, "num": i}
-
-                if "created_at" in meta:
-                    metric["created_at"] = pendulum.parse(meta["created_at"])
-                    if "saved_at" in meta:
-                        metric["saved"] = pendulum.parse(
-                            meta["saved_at"]
-                        ).diff_for_humans(metric["created_at"])
-
-                if "params" in meta:
-                    metric.update(meta["params"])
-                if "tags" in meta:
-                    metric["tags"] = meta["tags"]
-                if "comments" in meta:
-                    metric["comment_count"] = len(meta["comments"])
-                if "links" in meta:
-                    metric["link_count"] = len(meta["links"])
                 if "metrics" in meta:
+                    # Need to generate new metric each time
                     for m in meta["metrics"]:
-                        metric[m["name"]] = m.get("value")
+                        metric = {"line": line, "num": i}
+
+                        if "created_at" in meta:
+                            metric["created_at"] = pendulum.parse(meta["created_at"])
+                            if "saved_at" in meta:
+                                metric["saved"] = pendulum.parse(
+                                    meta["saved_at"]
+                                ).diff_for_humans(metric["created_at"])
+
+                        if "params" in meta:
+                            metric.update(meta["params"])
+                        if "tags" in meta:
+                            metric["tags"] = meta["tags"]
+                        if "comments" in meta:
+                            metric["comment_count"] = len(meta["comments"])
+                        if "links" in meta:
+                            metric["link_count"] = len(meta["links"])
+
+                        metric["name"] = m.get("name")
+                        metric["value"] =  m.get("value")
+
                         for key in m.keys():
                             if key not in ("name", "value", "created_at"):
                                 if m[key] is not None:
@@ -116,7 +120,7 @@ class MetricViewer:
 
                         self._metrics.append(metric)
                 else:
-                    self._metrics.append(metric)
+                    self._metrics.append({"line": line, "num": i})
         self.table = pd.DataFrame(self._metrics)
 
     def __repr__(self) -> str:

--- a/cascade/meta/metric_viewer.py
+++ b/cascade/meta/metric_viewer.py
@@ -88,7 +88,8 @@ class MetricViewer:
                 except IndexError:
                     meta = {}
 
-                metric = {"line": viewer_root, "num": i}
+                _, line = os.path.split(viewer_root)
+                metric = {"line": line, "num": i}
 
                 if "created_at" in meta:
                     metric["created_at"] = pendulum.parse(meta["created_at"])
@@ -101,6 +102,12 @@ class MetricViewer:
                     metric.update({m["name"]: m.get("value") for m in meta["metrics"]})
                 if "params" in meta:
                     metric.update(meta["params"])
+                if "tags" in meta:
+                    metric["tags"] = meta["tags"]
+                if "comments" in meta:
+                    metric["comment_count"] = len(meta["comments"])
+                if "links" in meta:
+                    metric["link_count"] = len(meta["links"])
 
                 self._metrics.append(metric)
         self.table = pd.DataFrame(self._metrics)

--- a/cascade/meta/metric_viewer.py
+++ b/cascade/meta/metric_viewer.py
@@ -275,7 +275,8 @@ class MetricServer(Server):
         self._df_flatten = pd.DataFrame(
             map(lambda x: flatten(x, root_keys_to_ignore=["tags"]), df.to_dict("records"))
         )
-        self._df_flatten["tags"] = df["tags"].apply(lambda x: ",".join(x))
+        if any(df["tags"].apply(lambda x: x != [])):
+            self._df_flatten["tags"] = df["tags"].apply(lambda x: ",".join(x))
         dep_fig = go.Figure()
 
         return html.Div(


### PR DESCRIPTION
With the introduction of new metric system and meta like tags, links and comments in #233 viewers were not updated to handle them appropriately. To improve this `MetricViewer` was updated

MetricViewer now:
- Shows number of links and comments
- Shows tags as comma-separated list for easy filtering
- Handles metrics differently now - has separate column `name` and `value`

Additional fixes:
- Adds forgotten in 0.13.0 `host` and `port` arguments to the CLI command