### PR TITLE
Filter

### DIFF
--- a/cascade/data/__init__.py
+++ b/cascade/data/__init__.py
@@ -27,6 +27,7 @@ from .dataset import (
     SizedDataset,
     Wrapper,
 )
+from .filter import Filter
 from .folder_dataset import FolderDataset
 from .functions import dataset, modifier
 from .modifier import BaseModifier, IteratorModifier, Modifier, Sampler

--- a/cascade/data/__init__.py
+++ b/cascade/data/__init__.py
@@ -27,7 +27,7 @@ from .dataset import (
     SizedDataset,
     Wrapper,
 )
-from .filter import Filter
+from .filter import Filter, IteratorFilter
 from .folder_dataset import FolderDataset
 from .functions import dataset, modifier
 from .modifier import BaseModifier, IteratorModifier, Modifier, Sampler

--- a/cascade/data/dataset.py
+++ b/cascade/data/dataset.py
@@ -13,7 +13,7 @@ limitations under the License.
 
 import warnings
 from abc import abstractmethod
-from typing import Any, Generator, Generic, Iterable, Sequence, Sized, TypeVar
+from typing import Any, Generator, Generic, Iterable, Iterator, Sequence, Sized, TypeVar
 
 from ..base import PipeMeta, Traceable
 
@@ -54,6 +54,8 @@ class IteratorDataset(BaseDataset[T], Iterable[T]):
     An abstract class to represent a dataset as
     an iterable object
     """
+    def __iter__(self) -> Iterator[T]:
+        return super().__iter__()
 
 
 class Dataset(BaseDataset[T], Sized):

--- a/cascade/data/filter.py
+++ b/cascade/data/filter.py
@@ -1,0 +1,57 @@
+"""
+Copyright 2022-2024 Ilia Moiseev
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import Any, Callable
+
+from .dataset import Dataset
+from .modifier import Sampler
+
+
+class Filter(Sampler):
+    """
+    Filter for Datasets with length. Uses a function
+    to create a mask of items that will remain
+    """
+    def __init__(self, dataset: Dataset, filter_fn: Callable, *args: Any, **kwargs: Any) -> None:
+        """
+        Filter a dataset using a filter function.
+        Does not accumulate items in memory, will store only an index mask.
+
+        Parameters
+        ----------
+        dataset: Dataset
+            A dataset to filter
+        filter_fn: Callable
+            A function to be applied to every item of a dataset -
+            should return bool. Will be called on every item on `__init__`.
+
+        Raises
+        ------
+        RuntimeError
+            If `filter_fn` raises an exception
+        """
+        self._mask = []
+        for i in range(len(dataset)):
+            try:
+                result = filter_fn(dataset[i])
+                if result:
+                    self._mask.append(i)
+            except Exception as e:
+                raise RuntimeError(f"Error when filtering dataset on index: {i}") from e
+        super().__init__(dataset, len(self._mask), *args, **kwargs)
+
+    def __getitem__(self, index: Any):
+        return self._dataset[self._mask[index]]

--- a/cascade/tests/data/test_filter.py
+++ b/cascade/tests/data/test_filter.py
@@ -1,0 +1,45 @@
+"""
+Copyright 2022-2024 Ilia Moiseev
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import os
+import sys
+
+import pytest
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
+sys.path.append(os.path.dirname(SCRIPT_DIR))
+
+from cascade.data import Filter, Wrapper
+
+
+@pytest.mark.parametrize(
+    "arr, func, res",
+    [
+        ([1, 2, 3, 4, 5], lambda x: x < 2, [1]),
+        (["a", "aa", "aaa", ""], lambda x: len(x), ["a", "aa", "aaa"]),
+    ],
+)
+def test_filter(arr, func, res):
+    ds = Wrapper(arr)
+    ds = Filter(ds, func)
+    assert [item for item in ds] == res
+
+
+def test_empty_filter():
+    ds = Wrapper([0, 1, 2, 3, 4])
+
+    with pytest.raises(AssertionError):
+        ds = Filter(ds, lambda x: x > 4)

--- a/cascade/tests/data/test_filter.py
+++ b/cascade/tests/data/test_filter.py
@@ -43,3 +43,15 @@ def test_empty_filter():
 
     with pytest.raises(AssertionError):
         ds = Filter(ds, lambda x: x > 4)
+
+
+def test_runtime_error():
+    def two_is_bad(i):
+        if i == 2:
+            raise ValueError("No, 2 is bad!!!")
+        return True
+
+    ds = Wrapper([0, 1, 2, 3])
+
+    with pytest.raises(RuntimeError):
+        ds = Filter(ds, two_is_bad)


### PR DESCRIPTION
This PR adds `Filter` and `IteratorFilter` datasets into `cascade.data`.
Filters accept functions that return bool values when receiving dataset items and then use their output to filter values.

For regular datasets with length define the `Filter` is `Sampler` meaning that it changes the length of a dataset
For datasets that are built around iterables `Filter` is `Modifier`

If Filter makes the length of a regular dataset 0 then `Sampler` will raise an `AssertionError` on creation