### PR TITLE
Artifact management

### DIFF
--- a/cascade/cli/__init__.py
+++ b/cascade/cli/__init__.py
@@ -1,0 +1,15 @@
+"""
+Copyright 2022-2024 Ilia Moiseev
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""

--- a/cascade/cli/artifact.py
+++ b/cascade/cli/artifact.py
@@ -1,4 +1,61 @@
+"""
+Copyright 2022-2024 Ilia Moiseev
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import os
+import traceback
+from collections import Counter
+from dataclasses import dataclass
+from typing import List, Literal, Optional
+
 import click
+
+
+@dataclass
+class RemoveResult:
+    """
+    OKAY - file was deleted without any problems
+
+    MISS - the artifact folder was not found or empty
+
+    FAIL - something went wrong when removing a file
+    """
+    status: Literal["OKAY", "MISS", "FAIL"]
+    path: Optional[str] = None
+    traceback: Optional[str] = None
+
+
+def remove_files(path: str) -> List[RemoveResult]:
+    if not os.path.exists(path):
+        return [RemoveResult("MISS")]
+
+    files = os.listdir(path)
+    if len(files) == 0:
+        return [RemoveResult("MISS")]
+
+    results = []
+    for name in files:
+        file_path = os.path.join(path, name)
+        try:
+            os.remove(file_path)
+        except Exception:
+            tb = traceback.format_exc()
+            results.append(RemoveResult("FAIL", traceback=tb, path=file_path))
+        else:
+            results.append(RemoveResult("OKAY"))
+    return results
 
 
 @click.group("artifact")
@@ -12,7 +69,24 @@ def artifact(ctx):
 @artifact.command("rm")
 @click.pass_context
 def artifact_rm(ctx):
-    if ctx.obj["type"] != "model":
-        click.echo(f"Cannot remove an artifact from {ctx.obj['type']}")
+    results_list = []
+    flat_results = []
+    if ctx.obj["type"] == "model":
+        results = remove_files(os.path.join(ctx.obj["cwd"], "artifacts"))
+        results_list.append(results)
+        flat_results.extend(results)
+    else:
+        raise NotImplementedError()
 
-    raise NotImplementedError()
+    c = Counter(res.status for res in flat_results)
+
+    click.echo(f"Found {c['OKAY'] + c['FAIL']} files in {len(results_list)} models")
+    click.echo(f"Removed: {c['OKAY']}")
+    click.echo(f"Missing files: {c['MISS']}")
+    click.echo(f"Failed: {c['FAIL']}")
+
+    if c["FAIL"] != 0:
+        for res in flat_results:
+            if res.status == "FAIL":
+                click.echo(f"Failed to remove {res.path}")
+                click.echo(res.traceback)

--- a/cascade/cli/artifact.py
+++ b/cascade/cli/artifact.py
@@ -1,0 +1,18 @@
+import click
+
+
+@click.group("artifact")
+@click.pass_context
+def artifact(ctx):
+    """
+    Manage artifacts
+    """
+
+
+@artifact.command("rm")
+@click.pass_context
+def artifact_rm(ctx):
+    if ctx.obj["type"] != "model":
+        click.echo(f"Cannot remove an artifact from {ctx.obj['type']}")
+
+    raise NotImplementedError()

--- a/cascade/cli/artifact.py
+++ b/cascade/cli/artifact.py
@@ -102,6 +102,9 @@ def artifact(ctx):
 @artifact.command("rm")
 @click.pass_context
 def artifact_rm(ctx):
+    """
+    Remove artifacts from the whole container recursively
+    """
     results_list = []
     flat_results = []
     if ctx.obj["type"] == "model":

--- a/cascade/cli/artifact.py
+++ b/cascade/cli/artifact.py
@@ -61,7 +61,7 @@ def remove_files(path: str) -> List[RemoveResult]:
 
 
 def remove_model_artifacts(path) -> List[RemoveResult]:
-    return remove_files(path, "artifacts")
+    return remove_files(os.path.join(path, "artifacts"))
 
 
 def remove_line_artifacts(path) -> List[List[RemoveResult]]:

--- a/cascade/cli/cli.py
+++ b/cascade/cli/cli.py
@@ -15,71 +15,16 @@ limitations under the License.
 """
 
 import os
-from math import ceil
-from typing import Any, Dict, List
 
 import click
 
 from ..base import MetaHandler, MetaIOError
-
-
-def create_container(type: str, cwd: str) -> Any:
-    if type == "line":
-        from cascade.models import ModelLine
-
-        return ModelLine(cwd)
-    elif type == "repo":
-        from cascade.models import ModelRepo
-
-        return ModelRepo(cwd)
-    elif type == "workspace":
-        from cascade.models import Workspace
-
-        return Workspace(cwd)
-    else:
-        return
-
-
-def comments_table(comments: List[Dict[str, str]]) -> str:
-    import pendulum
-
-    left_limit = 50
-    between_cols = 3
-    w, _ = os.get_terminal_size()
-
-    comm_meta = []
-    comm_date = []
-    for c in comments:
-        comm_meta.append(", ".join((c["id"], c["user"], c["host"])))
-        date = pendulum.parse(c["timestamp"]).diff_for_humans(pendulum.now())
-        comm_date.append(date)
-
-    w_left = max(max([len(r1) for r1 in comm_meta]), max([len(r2) for r2 in comm_date]))
-    w_left = min(w_left, left_limit)
-    w_right = w - (w_left + between_cols)
-
-    table = ""
-    for i, c in enumerate(comments):
-        # Minimum two rows for comments meta data
-        n_rows = max(2, ceil(len(c["message"]) / w_right))
-        for row in range(n_rows):
-            if row == 0:
-                table += (
-                    comm_meta[i]
-                    if len(comm_meta[i]) <= left_limit
-                    else comm_meta[i][: left_limit - 3] + "..."
-                )
-                table += " " * (w_left - min(len(comm_meta[i]), left_limit) + between_cols)
-            elif row == 1:
-                table += comm_date[i]
-                table += " " * (w_left - len(comm_date[i]) + between_cols)
-            else:
-                table += " " * (w_left + between_cols)
-
-            # Output comment's text by batches
-            table += c["message"][row * w_right : min((row + 1) * w_right, len(c["message"]))]
-        table += "\n\n"
-    return table
+from .artifact import artifact
+from .comment import comment
+from .common import create_container
+from .desc import desc
+from .tag import tag
+from .view import view
 
 
 @click.group
@@ -144,180 +89,6 @@ def cat(ctx, p):
             click.echo(pformat(meta))
 
 
-@cli.group
-@click.pass_context
-def view(ctx):
-    """
-    Different viewers
-    """
-    pass
-
-
-@view.command("history")
-@click.pass_context
-@click.option("--host", type=str, default="localhost")
-@click.option("--port", type=int, default=8050)
-@click.option("-l", type=int, help="The number of last lines to show")
-@click.option("-m", type=int, help="The number of last models to show")
-@click.option("-p", type=int, default=3, help="Update period in seconds")
-def view_history(ctx, host, port, l, m, p):  # noqa: E741
-    if ctx.obj.get("meta"):
-        container = create_container(ctx.obj["type"], ctx.obj["cwd"])
-        if not container:
-            click.echo(f"Cannot open History Viewer in object of type `{ctx.obj['type']}`")
-            return
-
-        from ..meta import HistoryViewer
-
-        HistoryViewer(container, last_lines=l, last_models=m, update_period_sec=p).serve(
-            host=host, port=port
-        )
-
-
-@view.command("metric")
-@click.pass_context
-@click.option("--host", type=str, default="localhost")
-@click.option("--port", type=int, default=8050)
-@click.option("-p", type=int, default=50, help="Page size for table")
-@click.option("-i", type=str, multiple=True, help="Metrics or params to include")
-@click.option("-x", type=str, multiple=True, help="Metrics or params to exclude")
-def view_metric(ctx, host, port, p, i, x):
-    type = ctx.obj["type"]
-    if type == "repo":
-        from ..models import ModelRepo
-
-        container = ModelRepo(ctx.obj["cwd"])
-    elif type == "line":
-        from ..models import ModelLine
-
-        container = ModelLine(ctx.obj["cwd"])
-    else:
-        click.echo(f"Cannot open Metric Viewer in object of type `{type}`")
-        return
-
-    from ..meta import MetricViewer
-
-    i = None if len(i) == 0 else list(i)
-    x = None if len(x) == 0 else list(x)
-    MetricViewer(container).serve(page_size=p, include=i, exclude=x, host=host, port=port)
-
-
-@view.command("diff")
-@click.pass_context
-@click.option("--host", type=str, default="localhost")
-@click.option("--port", type=int, default=8050)
-def view_diff(ctx, host, port):
-    from ..meta import DiffViewer
-
-    DiffViewer(ctx.obj["cwd"]).serve(host=host, port=port)
-
-
-@cli.group
-def comment():
-    """
-    Manage comments
-    """
-
-
-@comment.command("add")
-@click.pass_context
-@click.option("-c", prompt="Comment")
-def comment_add(ctx, c):
-    if not ctx.obj.get("meta"):
-        return
-
-    from cascade.base import TraceableOnDisk
-    tr = TraceableOnDisk(ctx.obj["cwd"], meta_fmt=ctx.obj["meta_fmt"])
-    tr.comment(c)
-
-
-@comment.command("ls")
-@click.pass_context
-def comment_ls(ctx):
-    comments = ctx.obj["meta"][0].get("comments")
-    if comments:
-        t = comments_table(comments)
-        click.echo(t)
-    else:
-        click.echo("No comments here")
-
-    container = create_container(ctx.obj.get("type"), ctx.obj.get("cwd"))
-    if container:
-        from cascade.models import ModelLine
-
-        comment_counter = 0
-        if isinstance(container, ModelLine):
-            for i in range(len(container)):
-                meta = container.load_model_meta(i)
-                if "comments" in meta[0]:
-                    comment_counter += len(meta[0]["comments"])
-        else:
-            for item in container:
-                meta = item.load_meta()
-                if "comments" in meta[0]:
-                    comment_counter += len(meta[0]["comments"])
-
-        click.echo(f"{comment_counter} comment{'s' if comment_counter != 1 else ''} inside total")
-
-
-@comment.command("rm")
-@click.pass_context
-@click.argument("id")
-def comment_rm(ctx, id):
-    if not ctx.obj.get("meta"):
-        return
-
-    from cascade.base import TraceableOnDisk
-
-    tr = TraceableOnDisk(ctx.obj["cwd"], meta_fmt=ctx.obj["meta_fmt"])
-    tr.remove_comment(id)
-
-
-@cli.group
-@click.pass_context
-def tag(ctx):
-    """
-    Manage tags
-    """
-    pass
-
-
-@tag.command("add")
-@click.pass_context
-@click.argument("t", nargs=-1)
-def tag_add(ctx, t):
-    if not ctx.obj.get("meta"):
-        return
-
-    from cascade.base import TraceableOnDisk
-
-    tr = TraceableOnDisk(ctx.obj["cwd"], meta_fmt=ctx.obj["meta_fmt"])
-    tr.tag(t)
-
-
-@tag.command("ls")
-@click.pass_context
-def tag_ls(ctx):
-    if not ctx.obj.get("meta"):
-        return
-
-    tags = ctx.obj["meta"][0].get("tags")
-    click.echo(tags)
-
-
-@tag.command("rm")
-@click.pass_context
-@click.argument("t", nargs=-1)
-def tag_rm(ctx, t):
-    if not ctx.obj.get("meta"):
-        return
-
-    from cascade.base import TraceableOnDisk
-
-    tr = TraceableOnDisk(ctx.obj["cwd"], meta_fmt=ctx.obj["meta_fmt"])
-    tr.remove_tag(t)
-
-
 @cli.command("migrate")
 @click.pass_context
 def migrate(ctx):
@@ -334,42 +105,11 @@ def migrate(ctx):
     migrate_repo_v0_13(ctx.obj.get("cwd"))
 
 
-@cli.group("artifact")
-@click.pass_context
-def artifact(ctx):
-    """
-    Manage artifacts
-    """
-
-
-@artifact.command("rm")
-@click.pass_context
-def artifact_rm(ctx):
-    if ctx.obj["type"] != "model":
-        click.echo(f"Cannot remove an artifact from {ctx.obj['type']}")
-
-    raise NotImplementedError()
-
-
-@cli.group("desc")
-@click.pass_context
-def desc(ctx):
-    """
-    Manage descriptions
-    """
-
-
-@desc.command("add")
-@click.pass_context
-@click.option("-d", prompt="Description: ")
-def desc_add(ctx, d):
-    if not ctx.obj.get("meta"):
-        return
-
-    from cascade.base import TraceableOnDisk
-
-    tr = TraceableOnDisk(ctx.obj["cwd"], meta_fmt=ctx.obj["meta_fmt"])
-    tr.describe(d)
+cli.add_command(artifact)
+cli.add_command(comment)
+cli.add_command(desc)
+cli.add_command(tag)
+cli.add_command(view)
 
 
 if __name__ == "__main__":

--- a/cascade/cli/comment.py
+++ b/cascade/cli/comment.py
@@ -1,3 +1,19 @@
+"""
+Copyright 2022-2024 Ilia Moiseev
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 import os
 from math import ceil
 from typing import Dict, List

--- a/cascade/cli/comment.py
+++ b/cascade/cli/comment.py
@@ -1,0 +1,115 @@
+import os
+from math import ceil
+from typing import Dict, List
+
+import click
+
+from .common import create_container
+
+
+def comments_table(comments: List[Dict[str, str]]) -> str:
+    import pendulum
+
+    left_limit = 50
+    between_cols = 3
+    w, _ = os.get_terminal_size()
+
+    comm_meta = []
+    comm_date = []
+    for c in comments:
+        comm_meta.append(", ".join((c["id"], c["user"], c["host"])))
+        date = pendulum.parse(c["timestamp"]).diff_for_humans(pendulum.now())
+        comm_date.append(date)
+
+    w_left = max(max([len(r1) for r1 in comm_meta]), max([len(r2) for r2 in comm_date]))
+    w_left = min(w_left, left_limit)
+    w_right = w - (w_left + between_cols)
+
+    table = ""
+    for i, c in enumerate(comments):
+        # Minimum two rows for comments meta data
+        n_rows = max(2, ceil(len(c["message"]) / w_right))
+        for row in range(n_rows):
+            if row == 0:
+                table += (
+                    comm_meta[i]
+                    if len(comm_meta[i]) <= left_limit
+                    else comm_meta[i][: left_limit - 3] + "..."
+                )
+                table += " " * (w_left - min(len(comm_meta[i]), left_limit) + between_cols)
+            elif row == 1:
+                table += comm_date[i]
+                table += " " * (w_left - len(comm_date[i]) + between_cols)
+            else:
+                table += " " * (w_left + between_cols)
+
+            # Output comment's text by batches
+            table += c["message"][row * w_right : min((row + 1) * w_right, len(c["message"]))]
+        table += "\n\n"
+    return table
+
+
+@click.command("add")
+@click.pass_context
+@click.option("-c", prompt="Comment")
+def comment_add(ctx, c):
+    if not ctx.obj.get("meta"):
+        return
+
+    from cascade.base import TraceableOnDisk
+    tr = TraceableOnDisk(ctx.obj["cwd"], meta_fmt=ctx.obj["meta_fmt"])
+    tr.comment(c)
+
+
+@click.command("ls")
+@click.pass_context
+def comment_ls(ctx):
+    comments = ctx.obj["meta"][0].get("comments")
+    if comments:
+        t = comments_table(comments)
+        click.echo(t)
+    else:
+        click.echo("No comments here")
+
+    container = create_container(ctx.obj.get("type"), ctx.obj.get("cwd"))
+    if container:
+        from cascade.models import ModelLine
+
+        comment_counter = 0
+        if isinstance(container, ModelLine):
+            for i in range(len(container)):
+                meta = container.load_model_meta(i)
+                if "comments" in meta[0]:
+                    comment_counter += len(meta[0]["comments"])
+        else:
+            for item in container:
+                meta = item.load_meta()
+                if "comments" in meta[0]:
+                    comment_counter += len(meta[0]["comments"])
+
+        click.echo(f"{comment_counter} comment{'s' if comment_counter != 1 else ''} inside total")
+
+
+@click.command("rm")
+@click.pass_context
+@click.argument("id")
+def comment_rm(ctx, id):
+    if not ctx.obj.get("meta"):
+        return
+
+    from cascade.base import TraceableOnDisk
+
+    tr = TraceableOnDisk(ctx.obj["cwd"], meta_fmt=ctx.obj["meta_fmt"])
+    tr.remove_comment(id)
+
+
+@click.group
+def comment():
+    """
+    Manage comments
+    """
+
+
+comment.add_command(comment_add)
+comment.add_command(comment_ls)
+comment.add_command(comment_rm)

--- a/cascade/cli/common.py
+++ b/cascade/cli/common.py
@@ -1,3 +1,19 @@
+"""
+Copyright 2022-2024 Ilia Moiseev
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from typing import Any
 
 

--- a/cascade/cli/common.py
+++ b/cascade/cli/common.py
@@ -1,0 +1,18 @@
+from typing import Any
+
+
+def create_container(type: str, cwd: str) -> Any:
+    if type == "line":
+        from cascade.models import ModelLine
+
+        return ModelLine(cwd)
+    elif type == "repo":
+        from cascade.models import ModelRepo
+
+        return ModelRepo(cwd)
+    elif type == "workspace":
+        from cascade.models import Workspace
+
+        return Workspace(cwd)
+    else:
+        return

--- a/cascade/cli/desc.py
+++ b/cascade/cli/desc.py
@@ -1,3 +1,19 @@
+"""
+Copyright 2022-2024 Ilia Moiseev
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 import click
 
 

--- a/cascade/cli/desc.py
+++ b/cascade/cli/desc.py
@@ -1,0 +1,22 @@
+import click
+
+
+@click.group("desc")
+@click.pass_context
+def desc(ctx):
+    """
+    Manage descriptions
+    """
+
+
+@desc.command("add")
+@click.pass_context
+@click.option("-d", prompt="Description: ")
+def desc_add(ctx, d):
+    if not ctx.obj.get("meta"):
+        return
+
+    from cascade.base import TraceableOnDisk
+
+    tr = TraceableOnDisk(ctx.obj["cwd"], meta_fmt=ctx.obj["meta_fmt"])
+    tr.describe(d)

--- a/cascade/cli/tag.py
+++ b/cascade/cli/tag.py
@@ -1,3 +1,19 @@
+"""
+Copyright 2022-2024 Ilia Moiseev
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 import click
 
 

--- a/cascade/cli/tag.py
+++ b/cascade/cli/tag.py
@@ -1,0 +1,51 @@
+import click
+
+
+@click.command("add")
+@click.pass_context
+@click.argument("t", nargs=-1)
+def tag_add(ctx, t):
+    if not ctx.obj.get("meta"):
+        return
+
+    from cascade.base import TraceableOnDisk
+
+    tr = TraceableOnDisk(ctx.obj["cwd"], meta_fmt=ctx.obj["meta_fmt"])
+    tr.tag(t)
+
+
+@click.command("ls")
+@click.pass_context
+def tag_ls(ctx):
+    if not ctx.obj.get("meta"):
+        return
+
+    tags = ctx.obj["meta"][0].get("tags")
+    click.echo(tags)
+
+
+@click.command("rm")
+@click.pass_context
+@click.argument("t", nargs=-1)
+def tag_rm(ctx, t):
+    if not ctx.obj.get("meta"):
+        return
+
+    from cascade.base import TraceableOnDisk
+
+    tr = TraceableOnDisk(ctx.obj["cwd"], meta_fmt=ctx.obj["meta_fmt"])
+    tr.remove_tag(t)
+
+
+@click.group
+@click.pass_context
+def tag(ctx):
+    """
+    Manage tags
+    """
+    pass
+
+
+tag.add_command(tag_add)
+tag.add_command(tag_ls)
+tag.add_command(tag_rm)

--- a/cascade/cli/view.py
+++ b/cascade/cli/view.py
@@ -1,3 +1,19 @@
+"""
+Copyright 2022-2024 Ilia Moiseev
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 import click
 
 from .common import create_container

--- a/cascade/cli/view.py
+++ b/cascade/cli/view.py
@@ -1,0 +1,76 @@
+import click
+
+from .common import create_container
+
+
+@click.command("history")
+@click.pass_context
+@click.option("--host", type=str, default="localhost")
+@click.option("--port", type=int, default=8050)
+@click.option("-l", type=int, help="The number of last lines to show")
+@click.option("-m", type=int, help="The number of last models to show")
+@click.option("-p", type=int, default=3, help="Update period in seconds")
+def view_history(ctx, host, port, l, m, p):  # noqa: E741
+    if ctx.obj.get("meta"):
+        container = create_container(ctx.obj["type"], ctx.obj["cwd"])
+        if not container:
+            click.echo(f"Cannot open History Viewer in object of type `{ctx.obj['type']}`")
+            return
+
+        from ..meta import HistoryViewer
+
+        HistoryViewer(container, last_lines=l, last_models=m, update_period_sec=p).serve(
+            host=host, port=port
+        )
+
+
+@click.command("metric")
+@click.pass_context
+@click.option("--host", type=str, default="localhost")
+@click.option("--port", type=int, default=8050)
+@click.option("-p", type=int, default=50, help="Page size for table")
+@click.option("-i", type=str, multiple=True, help="Metrics or params to include")
+@click.option("-x", type=str, multiple=True, help="Metrics or params to exclude")
+def view_metric(ctx, host, port, p, i, x):
+    type = ctx.obj["type"]
+    if type == "repo":
+        from ..models import ModelRepo
+
+        container = ModelRepo(ctx.obj["cwd"])
+    elif type == "line":
+        from ..models import ModelLine
+
+        container = ModelLine(ctx.obj["cwd"])
+    else:
+        click.echo(f"Cannot open Metric Viewer in object of type `{type}`")
+        return
+
+    from ..meta import MetricViewer
+
+    i = None if len(i) == 0 else list(i)
+    x = None if len(x) == 0 else list(x)
+    MetricViewer(container).serve(page_size=p, include=i, exclude=x, host=host, port=port)
+
+
+@click.command("diff")
+@click.pass_context
+@click.option("--host", type=str, default="localhost")
+@click.option("--port", type=int, default=8050)
+def view_diff(ctx, host, port):
+    from ..meta import DiffViewer
+
+    DiffViewer(ctx.obj["cwd"]).serve(host=host, port=port)
+
+
+@click.group
+@click.pass_context
+def view(ctx):
+    """
+    Different viewers
+    """
+    pass
+
+
+view.add_command(view_diff)
+view.add_command(view_history)
+view.add_command(view_metric)

--- a/cascade/models/trainer.py
+++ b/cascade/models/trainer.py
@@ -20,7 +20,6 @@ from typing import Any, Dict, Iterable, Optional, Tuple, Union
 import pendulum
 
 from ..base import Meta, Traceable, raise_not_implemented
-from ..data import BaseDataset
 from ..models import Model, ModelLine, ModelRepo
 
 logger = logging.getLogger(__name__)
@@ -160,10 +159,10 @@ class BasicTrainer(Trainer):
         })
         line.link(self)
 
-        if isinstance(train_data, BaseDataset):
+        if hasattr(train_data, "get_meta"):
             line.link(train_data)
 
-        if isinstance(test_data, BaseDataset):
+        if hasattr(test_data, "get_meta"):
             line.link(test_data)
 
         if start_from is not None:

--- a/cascade/tests/cli/test_artifact.py
+++ b/cascade/tests/cli/test_artifact.py
@@ -1,0 +1,80 @@
+"""
+Copyright 2022-2024 Ilia Moiseev
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import os
+import sys
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
+sys.path.append(os.path.dirname(SCRIPT_DIR))
+from cascade.base import MetaHandler
+from cascade.cli.cli import cli
+from cascade.models import BasicModel
+
+
+class TestModel(BasicModel):
+    def save_artifact(self, path: str):
+        with open(os.path.join(path, "artifact.txt"), "w") as f:
+            f.write("Hello")
+
+
+def test_rm_model(tmp_path_str):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path_str) as td:
+        artifact_path = os.path.join(td, "artifacts")
+        os.makedirs(artifact_path)
+        model = TestModel()
+        model.save_artifact(artifact_path)
+        MetaHandler.write_dir(td, model.get_meta())
+
+        assert os.path.exists(
+            os.path.join(td, "artifacts", "artifact.txt")
+        )
+
+        result = runner.invoke(cli, args=["artifact", "rm"])
+        assert result.exit_code == 0
+
+        assert not os.path.exists(
+            os.path.join(td, "artifacts", "artifact.txt")
+        )
+
+
+def test_rm_model_error(tmp_path_str):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path_str) as td:
+        artifact_path = os.path.join(td, "artifacts")
+        os.makedirs(artifact_path)
+        model = TestModel()
+        model.save_artifact(artifact_path)
+        MetaHandler.write_dir(td, model.get_meta())
+
+        assert os.path.exists(
+            os.path.join(td, "artifacts", "artifact.txt")
+        )
+
+        with patch('os.remove') as mocked_remove:
+            mocked_remove.side_effect = OSError()
+
+            result = runner.invoke(cli, args=["artifact", "rm"])
+            assert result.exit_code == 0
+
+            mocked_remove.assert_called_once_with(os.path.join(td, "artifacts", "artifact.txt"))
+
+            assert os.path.exists(
+                os.path.join(td, "artifacts", "artifact.txt")
+            )


### PR DESCRIPTION
`cascade artifact rm` inside a folder of `Workspace`, `Repo`, `Line` or `Model` will remove files from artifact folders in recursive manner, which is useful for cleaning space from old model binaries