### PR TITLE
v0.14.1

### DIFF
--- a/cascade/data/apply_modifier.py
+++ b/cascade/data/apply_modifier.py
@@ -17,7 +17,7 @@ limitations under the License.
 import random
 from typing import Any, Callable, Iterator, Optional
 
-from .dataset import Dataset, T
+from .dataset import T
 from .modifier import Modifier
 from .utils import DatasetOrIterator
 
@@ -73,11 +73,8 @@ class ApplyModifier(Modifier[T]):
             if rnd > self._p:
                 return super().__getitem__(index)
 
-        if isinstance(self._dataset, Dataset):
             item = self._dataset[index]
             return self._func(item)
-        else:
-            raise TypeError(f"The underlying dataset is not a Dataset, but {type(self._dataset)}")
 
     def __iter__(self) -> Iterator[T]:
         for item in self._dataset:

--- a/cascade/data/cyclic_sampler.py
+++ b/cascade/data/cyclic_sampler.py
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from typing import Iterator
+
 from .dataset import T
 from .modifier import Sampler
 
@@ -33,3 +35,7 @@ class CyclicSampler(Sampler[T]):
     def __getitem__(self, index: int) -> T:
         internal_index = index % len(self._dataset)
         return self._dataset[internal_index]
+
+    def __iter__(self) -> Iterator[T]:
+        for index in range(super().__len__()):
+            yield self.__getitem__(index)

--- a/cascade/tests/data/test_apply_modifier.py
+++ b/cascade/tests/data/test_apply_modifier.py
@@ -18,6 +18,7 @@ import os
 import sys
 
 import pytest
+
 from cascade.data import ApplyModifier, IteratorWrapper, Wrapper
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
@@ -36,6 +37,16 @@ def test_apply_modifier(arr, func):
     ds = Wrapper(arr)
     ds = ApplyModifier(ds, func)
     assert list(map(func, arr)) == [item for item in ds]
+
+
+def test_ds_coverage(dataset):
+    ds = ApplyModifier(dataset, lambda x: x)
+    for item in ds:
+        pass
+
+    if hasattr(dataset, "__len__"):
+        for i in range(len(ds)):
+            ds[i]
 
 
 @pytest.mark.parametrize("arr, func", data)

--- a/cascade/tests/data/test_cyclic_sampler.py
+++ b/cascade/tests/data/test_cyclic_sampler.py
@@ -45,3 +45,13 @@ def test_cycle():
         4,
         0,
     ]
+
+
+def test():
+    ds = CyclicSampler(Wrapper([1]), 2)
+
+    for i in range(len(ds)):
+        ds[i]
+
+    for i in ds:
+        pass

--- a/cascade/version.py
+++ b/cascade/version.py
@@ -16,6 +16,6 @@ limitations under the License.
 
 __ALL__ = ["__version__", "__author__", "__author_email__"]
 
-__version__ = "0.14.0"
+__version__ = "0.14.1"
 __author__ = "Ilia Moiseev"
 __author_email__ = "ilia.moiseev.5@yandex.ru"


### PR DESCRIPTION
Fixes:
- Fix check for input type in `ApplyModifier`
- Fix infinite iterations in `CyclicSampler`
- Remove Python 3.6 from supported versions