### PR TITLE
Handle missing init calls for Dataset

### DIFF
--- a/cascade/data/dataset.py
+++ b/cascade/data/dataset.py
@@ -13,8 +13,7 @@ limitations under the License.
 
 import warnings
 from abc import ABC, abstractmethod
-from typing import (Any, Generic, Iterable, Iterator, Optional, Sequence,
-                    Sized, TypeVar)
+from typing import Any, Generic, Iterable, Iterator, Optional, Sequence, Sized, TypeVar
 
 from ..base import Meta, Traceable
 from .data_card import DataCard
@@ -46,8 +45,13 @@ class BaseDataset(ABC, Generic[T], Traceable):
         """
         meta = super().get_meta()
         meta[0]["type"] = "dataset"
-        if self._data_card is not None:
-            meta[0]["data_card"] = self._data_card.to_dict()
+
+        # Someone may've missed the __init__ call and there
+        # will be no self._data_card
+        data_card = getattr(self, "_data_card", None)
+        if data_card:
+            data_card = data_card.to_dict()
+        meta[0]["data_card"] = data_card
         return meta
 
 
@@ -133,7 +137,9 @@ class Wrapper(Dataset):
 
 class SizedDataset(Dataset):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        warnings.warn("SizedDataset is deprecated since 0.14.0."
-                      " Consider using older version or migrate to"
-                      " Dataset, which is sized by default now")
+        warnings.warn(
+            "SizedDataset is deprecated since 0.14.0."
+            " Consider using older version or migrate to"
+            " Dataset, which is sized by default now"
+        )
         super().__init__(*args, **kwargs)

--- a/cascade/tests/data/test_dataset.py
+++ b/cascade/tests/data/test_dataset.py
@@ -24,8 +24,14 @@ import pytest
 MODULE_PATH = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
 sys.path.append(os.path.dirname(MODULE_PATH))
 
-from cascade.data import (BaseDataset, IteratorWrapper, Modifier, Sampler,
-                          Wrapper)
+from cascade.data import (
+    BaseDataset,
+    Dataset,
+    IteratorWrapper,
+    Modifier,
+    Sampler,
+    Wrapper,
+)
 
 
 class DummyDataset(BaseDataset):
@@ -131,3 +137,29 @@ def test_modifier_from_meta():
 def test_sampler():
     ds = Wrapper([1, 2, 3, 4])
     ds = Sampler(ds, 10)
+
+    assert len(ds) == 10
+
+
+class EmptyDataset(Dataset):
+    def __init__(self):
+        # Here we intenstionally do not call super().__init__()
+        # which is very common in practice and I think for now
+        # there is no need to actively forbid this
+        ...
+
+    def __getitem__(self, index):
+        return None
+
+    def __len__(self):
+        return 0
+
+
+def test_no_init_call():
+    ds = EmptyDataset()
+
+    assert ds[0] == None
+
+    meta = ds.get_meta()
+
+    assert len(meta) == 1


### PR DESCRIPTION
Fixed the problem of datasets not working if user forgets to call init in subclass