### PR TITLE
Handle external removes

### DIFF
--- a/cascade/tests/lines/test_model_line.py
+++ b/cascade/tests/lines/test_model_line.py
@@ -25,9 +25,9 @@ MODULE_PATH = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
 sys.path.append(os.path.dirname(MODULE_PATH))
 
 from cascade.base import MetaHandler, default_meta_format
+from cascade.lines import ModelLine
 from cascade.models import BasicModel
 from cascade.repos import Repo
-from cascade.lines import ModelLine
 from cascade.tests.conftest import DummyModel
 
 
@@ -63,17 +63,40 @@ def test_change_of_format(tmp_path_str, ext):
     assert len(glob.glob(os.path.join(tmp_path_str, "meta.*"))) == 1
 
 
-def test_same_index_check(model_line):
+def test_external_remove_first(model_line):
     for _ in range(5):
         model_line.save(BasicModel())
 
-    shutil.rmtree(os.path.join(model_line.get_root(), "00001"))
-    shutil.rmtree(os.path.join(model_line.get_root(), "00002"))
-    shutil.rmtree(os.path.join(model_line.get_root(), "00003"))
+    shutil.rmtree(os.path.join(model_line.get_root(), "00000"))
 
+    model_line = ModelLine(model_line.get_root())
     model_line.save(BasicModel())
 
     assert os.path.exists(os.path.join(model_line.get_root(), "00005"))
+
+
+def test_external_remove_middle(model_line):
+    for _ in range(5):
+        model_line.save(BasicModel())
+
+    shutil.rmtree(os.path.join(model_line.get_root(), "00002"))
+
+    model_line = ModelLine(model_line.get_root())
+    model_line.save(BasicModel())
+
+    assert os.path.exists(os.path.join(model_line.get_root(), "00005"))
+
+
+def test_external_remove_last(model_line):
+    for _ in range(5):
+        model_line.save(BasicModel())
+
+    shutil.rmtree(os.path.join(model_line.get_root(), "00004"))
+
+    model_line = ModelLine(model_line.get_root())
+    model_line.save(BasicModel())
+
+    assert os.path.exists(os.path.join(model_line.get_root(), "00004"))
 
 
 # TODO: write tests for exceptions
@@ -183,6 +206,7 @@ def test_model_names(tmp_path_str):
 
     line = ModelLine(tmp_path_str)
     assert line.get_model_names() == ["00000", "00001", "00002"]
+
 
 # TODO: write test for restoring line from repo
 

--- a/cascade/tests/repos/test_repo.py
+++ b/cascade/tests/repos/test_repo.py
@@ -298,13 +298,7 @@ def test_auto_line_name(tmp_path_str, ext):
 
     names = repo.get_line_names()
 
-    assert names == ["00000", "test", "00002", "00003"]
-
-    repo = Repo(str(tmp_path_str), meta_fmt=ext)
-
-    names = repo.get_line_names()
-
-    assert names == ["00000", "00002", "00003", "test"]
+    assert set(names) == {"00000", "test", "00001", "00002"}
 
 
 def test_external_remove_first(tmp_path_str):

--- a/cascade/tests/repos/test_repo.py
+++ b/cascade/tests/repos/test_repo.py
@@ -306,6 +306,15 @@ def test_auto_line_name(tmp_path_str, ext):
     assert names == ["00000", "00002", "00003", "test"]
 
 
+def test_external_remove_first(tmp_path_str): ...
+
+
+def test_external_remove_middle(tmp_path_str): ...
+
+
+def test_external_remove_last(tmp_path_str): ...
+
+
 @pytest.mark.skip
 def test_no_logging(tmp_path_str):
     Repo(tmp_path_str, log_history=False)

--- a/cascade/tests/repos/test_repo.py
+++ b/cascade/tests/repos/test_repo.py
@@ -13,6 +13,7 @@ limitations under the License.
 
 import glob
 import os
+import shutil
 import sys
 
 import pytest
@@ -306,13 +307,87 @@ def test_auto_line_name(tmp_path_str, ext):
     assert names == ["00000", "00002", "00003", "test"]
 
 
-def test_external_remove_first(tmp_path_str): ...
+def test_external_remove_first(tmp_path_str):
+    repo = Repo(str(tmp_path_str))
+    repo.add_line()
+    repo.add_line()
+    repo.add_line()
+    repo.add_line()
+
+    shutil.rmtree(os.path.join(repo.get_root(), "00000"))
+
+    repo = Repo(str(tmp_path_str))
+    repo.add_line()
+
+    assert repo.get_line_names() == [
+        "00001",
+        "00002",
+        "00003",
+        "00004",
+    ]
 
 
-def test_external_remove_middle(tmp_path_str): ...
+def test_external_remove_middle(tmp_path_str):
+    repo = Repo(str(tmp_path_str))
+    repo.add_line()
+    repo.add_line()
+    repo.add_line()
+    repo.add_line()
+
+    shutil.rmtree(os.path.join(repo.get_root(), "00001"))
+
+    repo = Repo(str(tmp_path_str))
+    repo.add_line()
+
+    assert repo.get_line_names() == [
+        "00000",
+        "00002",
+        "00003",
+        "00004",
+    ]
 
 
-def test_external_remove_last(tmp_path_str): ...
+def test_external_remove_last(tmp_path_str):
+    repo = Repo(str(tmp_path_str))
+    repo.add_line()
+    repo.add_line()
+    repo.add_line()
+    repo.add_line()
+
+    shutil.rmtree(os.path.join(repo.get_root(), "00003"))
+
+    repo = Repo(str(tmp_path_str))
+    repo.add_line()
+
+    assert repo.get_line_names() == [
+        "00000",
+        "00001",
+        "00002",
+        "00003",
+    ]
+
+
+def test_mixed_formats(tmp_path_str):
+    repo = Repo(str(tmp_path_str))
+    repo.add_line("00000")
+    repo.add_line("00001")
+    repo.add_line("a")
+    repo.add_line("b")
+    repo.add_line("c")
+
+    shutil.rmtree(os.path.join(repo.get_root(), "b"))
+
+    repo = Repo(str(tmp_path_str))
+    repo.add_line()
+
+    # I do not care about order here
+    assert set(repo.get_line_names()) == {
+        "00000",
+        "00001",
+        "00002",
+        "a",
+        "c",
+    }
 
 
 @pytest.mark.skip


### PR DESCRIPTION
This was an issue for a long time. When you delete the line in the middle of the repo, you get the error.
Now it is over - repos and lines handle deletion in the middle and will name new entity automatically starting from latest number.