### PR TITLE
Query update

### DIFF
--- a/cascade/cli/query.py
+++ b/cascade/cli/query.py
@@ -288,7 +288,7 @@ class Executor:
                     yield [{}]
         elif container_type == "repo":
             for name in container.get_line_names():
-                line = container.add_line(name)
+                line = container.add_line(name, line_type=None)
                 for meta in self.iterate_over_container(line, "line"):
                     yield meta
         elif container_type == "workspace":

--- a/cascade/cli/query.py
+++ b/cascade/cli/query.py
@@ -26,6 +26,13 @@ from ..base import MetaIOError
 from ..base.utils import get_terminal_width
 from .common import create_container
 
+OP_STOP_LIST = [
+    "subprocess",
+    "__import__",
+    "open",
+    "socket",
+]
+
 
 class QueryParsingError(Exception): ...
 
@@ -285,23 +292,27 @@ class Executor:
                 for meta in self.iterate_over_container(line, "line"):
                     yield meta
 
-    def validate_eval(self, expr: str) -> None:
-        tree = ast.parse(expr)
+    def _validate_module(self, tree: ast.AST):
         for node in ast.walk(tree):
             if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
                 if node.func.id in ("eval", "exec"):
                     raise QueryExecutionError("Nested eval/exec calls are not allowed")
 
-                if node.func.id in ("open", "socket", "subprocess"):
+                if node.func.id in (OP_STOP_LIST):
                     raise QueryExecutionError(
-                        "File system or network related builtins are not allowed"
+                        f"Found potentially dangerous method call, {node.func.id}"
                     )
 
             if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
                 if isinstance(node.func.value, ast.Name):
-                    if node.func.value.id in ["subprocess", "socket"]:
+                    if node.func.value.id in OP_STOP_LIST:
                         raise QueryExecutionError(
                             f"Found potentially dangerous method call: {node.func.attr}"
+                        )
+                if isinstance(node.func.value, ast.Call):
+                    if getattr(node.func.value.func, "id") in OP_STOP_LIST:
+                        raise QueryExecutionError(
+                            f"Found potentially dangerous method call: {node.func.value.func.id}"
                         )
 
             if isinstance(node, ast.FunctionDef):
@@ -309,6 +320,10 @@ class Executor:
 
             if isinstance(node, (ast.Import, ast.ImportFrom)):
                 raise QueryExecutionError("Imports are not allowed")
+
+    def validate_eval(self, expr: str) -> None:
+        tree = ast.parse(expr)
+        self._validate_module(tree)
 
     def eval_or_none(self, expr: str, context: Dict[str, Any]) -> Optional[Any]:
         try:
@@ -328,8 +343,8 @@ class Executor:
         data = []
         sorting_keys = []
 
+        # Small optimization
         # Validate once, then execute many times
-        # little optimization
         if q.filter_expr:
             self.validate_eval(q.filter_expr)
         if q.sort_expr:

--- a/cascade/cli/query.py
+++ b/cascade/cli/query.py
@@ -291,6 +291,11 @@ class Executor:
                 line = container.add_line(name)
                 for meta in self.iterate_over_container(line, "line"):
                     yield meta
+        elif container_type == "workspace":
+            for repo_name in container.get_repo_names():
+                repo = container.add_repo(repo_name)
+                for meta in self.iterate_over_container(repo, "repo"):
+                    yield meta
 
     def _validate_module(self, tree: ast.AST):
         for node in ast.walk(tree):

--- a/cascade/cli/query.py
+++ b/cascade/cli/query.py
@@ -58,7 +58,7 @@ class Result:
     columns: List[str]
     rows: int
     data: List[Dict[str, Any]]
-    time_s: int
+    time_s: float
 
 
 class QueryParser:
@@ -373,21 +373,12 @@ class Executor:
 
         if q.sort_expr is not None:
             # This one sorts the data by the order of sorting_keys
-            # First we make tuples of items and their indices
-            # then we use indices to make sortable elements
-            # we push values containing None to the end by
-            # placing boolean `is None` first
-            data = [
-                item
-                for _, item in sorted(
-                    enumerate(data),
-                    key=lambda i_item: (
-                        sorting_keys[i_item[0]] is None,
-                        sorting_keys[i_item[0]],
-                    ),
-                    reverse=q.desc,
-                )
-            ]
+            # we push values containing None to the end
+
+            present = [i for i in range(len(data)) if sorting_keys[i] is not None]
+            missing = [i for i in range(len(data)) if sorting_keys[i] is None]
+            present.sort(key=lambda i: sorting_keys[i], reverse=q.desc)
+            data = [data[i] for i in present + missing]
 
         if q.offset is not None:
             data = data[q.offset :]

--- a/cascade/cli/query.py
+++ b/cascade/cli/query.py
@@ -17,6 +17,7 @@ limitations under the License.
 import ast
 import time
 from dataclasses import dataclass
+from types import CodeType
 from typing import Any, Dict, List, Optional, Union
 
 import click
@@ -26,12 +27,85 @@ from ..base import MetaIOError
 from ..base.utils import get_terminal_width
 from .common import create_container
 
-OP_STOP_LIST = [
-    "subprocess",
-    "__import__",
-    "open",
-    "socket",
+NODE_ALLOW_LIST = [
+    ast.Expression,
+    ast.BoolOp,
+    ast.BinOp,
+    ast.UnaryOp,
+    ast.Compare,
+    ast.IfExp,
+    ast.And,
+    ast.Or,
+    ast.Not,
+    ast.Add,
+    ast.Sub,
+    ast.Mult,
+    ast.Div,
+    ast.Mod,
+    ast.Pow,
+    ast.Eq,
+    ast.NotEq,
+    ast.Store,
+    ast.Lt,
+    ast.LtE,
+    ast.Gt,
+    ast.GtE,
+    ast.In,
+    ast.NotIn,
+    ast.Is,
+    ast.IsNot,
+    ast.UAdd,
+    ast.USub,
+    ast.Name,
+    ast.Load,
+    ast.Constant,
+    ast.List,
+    ast.Tuple,
+    ast.Set,
+    ast.Dict,
+    ast.Subscript,
+    ast.Slice,
+    ast.Attribute,
+    ast.Call,
+    ast.ListComp,
+    ast.DictComp,
+    ast.SetComp,
+    ast.comprehension,
+    ast.GeneratorExp,
 ]
+
+ALLOWED_BUILTINS = {
+    "any": any,
+    "all": all,
+    "len": len,
+    "sum": sum,
+    "min": min,
+    "max": max,
+    "sorted": sorted,
+    "abs": abs,
+    "round": round,
+    "pow": pow,
+    "divmod": divmod,
+    "int": int,
+    "float": float,
+    "str": str,
+    "bool": bool,
+    "repr": repr,
+    "list": list,
+    "tuple": tuple,
+    "set": set,
+    "dict": dict,
+    "frozenset": frozenset,
+    "enumerate": enumerate,
+    "zip": zip,
+    "range": range,
+    "reversed": reversed,
+    "map": map,
+    "filter": filter,
+    "None": None,
+    "True": True,
+    "False": False,
+}
 
 
 class QueryParsingError(Exception): ...
@@ -297,50 +371,40 @@ class Executor:
                 for meta in self.iterate_over_container(repo, "repo"):
                     yield meta
 
-    def _validate_module(self, tree: ast.AST):
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
-                if node.func.id in ("eval", "exec"):
-                    raise QueryExecutionError("Nested eval/exec calls are not allowed")
-
-                if node.func.id in (OP_STOP_LIST):
-                    raise QueryExecutionError(
-                        f"Found potentially dangerous method call, {node.func.id}"
-                    )
-
-            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
-                if isinstance(node.func.value, ast.Name):
-                    if node.func.value.id in OP_STOP_LIST:
-                        raise QueryExecutionError(
-                            f"Found potentially dangerous method call: {node.func.attr}"
-                        )
-                if isinstance(node.func.value, ast.Call):
-                    if getattr(node.func.value.func, "id") in OP_STOP_LIST:
-                        raise QueryExecutionError(
-                            f"Found potentially dangerous method call: {node.func.value.func.id}"
-                        )
-
-            if isinstance(node, ast.FunctionDef):
-                raise QueryExecutionError("Function definitions are not allowed")
-
-            if isinstance(node, (ast.Import, ast.ImportFrom)):
-                raise QueryExecutionError("Imports are not allowed")
-
-    def validate_eval(self, expr: str) -> None:
-        tree = ast.parse(expr)
-        self._validate_module(tree)
-
-    def eval_or_none(self, expr: str, context: Dict[str, Any]) -> Optional[Any]:
+    def validate_and_compile(self, expr: str) -> CodeType:
         try:
-            return eval(expr, context.copy())
+            tree = ast.parse(expr, mode="eval")
+        except SyntaxError as e:
+            raise QueryExecutionError(
+                f"Failed to parse query expression: {expr}"
+            ) from e
+
+        for node in ast.walk(tree):
+            if type(node) not in NODE_ALLOW_LIST:
+                raise QueryExecutionError(
+                    f"{type(node).__name__} not allowed in a query"
+                )
+
+            if isinstance(node, ast.Attribute) and (
+                node.attr.startswith("__") or node.attr in ("format", "format_map")
+            ):
+                raise QueryExecutionError(f"attribute .{node.attr} not allowed")
+
+            if isinstance(node, ast.Name) and node.id.startswith("__"):
+                raise QueryExecutionError(f"name {node.id} not allowed")
+
+        return compile(tree, "query", "eval")
+
+    def eval_or_none(self, expr, context: Dict[str, Any]) -> Optional[Any]:
+        try:
+            return eval(expr, {"__builtins__": ALLOWED_BUILTINS}, context.copy())
         except Exception:
             return None
 
-    def select(self, ctx: Dict[str, Union[Field, Any]], columns: List[str]):
+    def select(self, ctx: Dict[str, Union[Field, Any]], columns: Dict[str, CodeType]):
         res = {}
         for col in columns:
-            self.validate_eval(col)
-            res[col] = self.eval_or_none(col, ctx)
+            res[col] = self.eval_or_none(columns[col], ctx)
         return res
 
     def execute(self, q: Query) -> Result:
@@ -350,23 +414,33 @@ class Executor:
 
         # Small optimization
         # Validate once, then execute many times
+
+        col2expr = {}
+        for col in q.columns:
+            col2expr[col] = self.validate_and_compile(col)
+
         if q.filter_expr:
-            self.validate_eval(q.filter_expr)
+            filter_expr = self.validate_and_compile(q.filter_expr)
+        else:
+            filter_expr = None
+
         if q.sort_expr:
-            self.validate_eval(q.sort_expr)
+            sort_expr = self.validate_and_compile(q.sort_expr)
+        else:
+            sort_expr = None
 
         # TODO: meta data is independent, can be highly parallel
         for meta in self.iterate_over_container(self.container, self.type):
             full_ctx = Field(meta[0]).to_dict()  # TODO: somehow deal with meta lists
-            ctx = self.select(full_ctx, q.columns)
+            ctx = self.select(full_ctx, col2expr)
 
-            if q.filter_expr:
-                result = self.eval_or_none(q.filter_expr, full_ctx)
+            if filter_expr:
+                result = self.eval_or_none(filter_expr, full_ctx)
                 if not result:
                     continue
 
-            if q.sort_expr:
-                sorting_key = self.eval_or_none(q.sort_expr, full_ctx)
+            if sort_expr:
+                sorting_key = self.eval_or_none(sort_expr, full_ctx)
                 sorting_keys.append(sorting_key)
 
             data.append(ctx)

--- a/cascade/cli/query.py
+++ b/cascade/cli/query.py
@@ -300,8 +300,8 @@ class Executor:
             if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
                 if isinstance(node.func.value, ast.Name):
                     if node.func.value.id in ["subprocess", "socket"]:
-                        self.dangerous_calls.append(
-                            f"Found dangerous method call: {node.func.attr}"
+                        raise QueryExecutionError(
+                            f"Found potentially dangerous method call: {node.func.attr}"
                         )
 
             if isinstance(node, ast.FunctionDef):

--- a/cascade/tests/cli/common.py
+++ b/cascade/tests/cli/common.py
@@ -19,9 +19,10 @@ from typing import Any, Dict, List
 
 import pytest
 
+from cascade.data import Wrapper
 from cascade.models import BasicModel
 from cascade.repos import Repo
-from cascade.lines import ModelLine
+from cascade.lines import DataLine, ModelLine
 from cascade.workspaces import Workspace
 
 
@@ -32,16 +33,22 @@ def init_workspace(path: str, params_list: List[Dict[str, Any]]):
 
 def init_repo(path: str, params_list: List[Dict[str, Any]]):
     Repo(path)
-    init_line(os.path.join(path, "line"), params_list)
+    init_model_line(os.path.join(path, "model_line"), params_list)
+    init_data_line(os.path.join(path, "data_line"))
 
 
-def init_line(path: str, params_list: List[Dict[str, Any]]):
+def init_model_line(path: str, params_list: List[Dict[str, Any]]):
     line = ModelLine(path)
 
     for p in params_list:
         model = BasicModel()
         model.params.update(p)
         line.save(model)
+
+
+def init_data_line(path: str):
+    line = DataLine(path)
+    line.save(Wrapper([]))
 
 
 @pytest.mark.parametrize("container_type", ["workspace", "repo", "model_line"])
@@ -53,6 +60,6 @@ def init_container(
     elif container_type == "repo":
         init_repo(temp_dir, params_list)
     elif container_type == "model_line":
-        init_line(temp_dir, params_list)
+        init_model_line(temp_dir, params_list)
     else:
         raise ValueError(f"Cannot init {container_type} container")

--- a/cascade/tests/cli/common.py
+++ b/cascade/tests/cli/common.py
@@ -14,17 +14,45 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import os
 from typing import Any, Dict, List
+
+import pytest
 
 from cascade.models import BasicModel
 from cascade.repos import Repo
+from cascade.lines import ModelLine
+from cascade.workspaces import Workspace
 
 
-def init_repo(temp_dir: str, params_list: List[Dict[str, Any]]):
-    repo = Repo(temp_dir)
-    line = repo.add_line()
+def init_workspace(path: str, params_list: List[Dict[str, Any]]):
+    Workspace(path)
+    init_repo(os.path.join(path, "repo"), params_list)
+
+
+def init_repo(path: str, params_list: List[Dict[str, Any]]):
+    Repo(path)
+    init_line(os.path.join(path, "line"), params_list)
+
+
+def init_line(path: str, params_list: List[Dict[str, Any]]):
+    line = ModelLine(path)
 
     for p in params_list:
         model = BasicModel()
         model.params.update(p)
         line.save(model)
+
+
+@pytest.mark.parametrize("container_type", ["workspace", "repo", "model_line"])
+def init_container(
+    temp_dir: str, params_list: List[Dict[str, Any]], container_type: str
+):
+    if container_type == "workspace":
+        init_workspace(temp_dir, params_list)
+    elif container_type == "repo":
+        init_repo(temp_dir, params_list)
+    elif container_type == "model_line":
+        init_line(temp_dir, params_list)
+    else:
+        raise ValueError(f"Cannot init {container_type} container")

--- a/cascade/tests/cli/common.py
+++ b/cascade/tests/cli/common.py
@@ -31,10 +31,13 @@ def init_workspace(path: str, params_list: List[Dict[str, Any]]):
     init_repo(os.path.join(path, "repo"), params_list)
 
 
-def init_repo(path: str, params_list: List[Dict[str, Any]]):
+def init_repo(
+    path: str, params_list: List[Dict[str, Any]], with_data_line: bool = True
+):
     Repo(path)
     init_model_line(os.path.join(path, "model_line"), params_list)
-    init_data_line(os.path.join(path, "data_line"))
+    if with_data_line:
+        init_data_line(os.path.join(path, "data_line"))
 
 
 def init_model_line(path: str, params_list: List[Dict[str, Any]]):

--- a/cascade/tests/cli/test_query.py
+++ b/cascade/tests/cli/test_query.py
@@ -18,14 +18,16 @@ import os
 import re
 import sys
 
+import pytest
 from click.testing import CliRunner
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
 sys.path.append(os.path.dirname(SCRIPT_DIR))
 from cascade.cli.cli import cli
 from cascade.cli.query import Field, QueryParsingError, QueryExecutionError, empty_field
-from cascade.tests.cli.common import init_repo
+from cascade.tests.cli.common import init_container
 
+CONTAINER_TYPES = ["workspace", "repo", "model_line"]
 PARAMS = [
     {"a": {"b": 0}, "l": [0, 1, 2, 3], "ord": 0},
     {"l": [0, 1, 2, 3], "ord": 1},
@@ -37,15 +39,25 @@ PARAMS = [
 ]
 
 
-def corrupt_model_meta(repo_root):
-    with open(os.path.join(repo_root, "00000", "00000", "meta.json"), "w") as f:
+def corrupt_model_meta(root, container_type):
+    if container_type == "model_line":
+        path = os.path.join(root, "00000", "meta.json")
+    elif container_type == "repo":
+        path = os.path.join(root, "line", "00000", "meta.json")
+    elif container_type == "workspace":
+        path = os.path.join(root, "repo", "line", "00000", "meta.json")
+    else:
+        raise ValueError(f"Unknown container type: {container_type}")
+
+    with open(path, "w") as f:
         f.write("{i am broken json")
 
 
-def test_parsing(tmp_path_str):
+@pytest.mark.parametrize("container_type", CONTAINER_TYPES)
+def test_parsing(tmp_path_str, container_type):
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path_str) as td:
-        init_repo(td, PARAMS)
+        init_container(td, PARAMS, container_type)
 
         result = runner.invoke(cli, args=["query", "params"])
         assert result.exit_code == 0
@@ -147,10 +159,11 @@ def test_parsing(tmp_path_str):
         assert result.exit_code == 0
 
 
-def test_parsing_error(tmp_path_str):
+@pytest.mark.parametrize("container_type", CONTAINER_TYPES)
+def test_parsing_error(tmp_path_str, container_type):
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path_str) as td:
-        init_repo(td, PARAMS)
+        init_container(td, PARAMS, container_type)
 
         result = runner.invoke(cli, args=["query"])
         assert result.exit_code == 1
@@ -167,10 +180,11 @@ def test_parsing_error(tmp_path_str):
         assert type(result.exception) is QueryParsingError
 
 
-def test_columns(tmp_path_str):
+@pytest.mark.parametrize("container_type", CONTAINER_TYPES)
+def test_columns(tmp_path_str, container_type):
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path_str) as td:
-        init_repo(td, PARAMS)
+        init_container(td, PARAMS, container_type)
 
         result = runner.invoke(cli, args=["query", "params"])
         assert result.stdout.split("\n")[3].strip() == str(
@@ -187,10 +201,11 @@ def test_columns(tmp_path_str):
         assert result.stdout.split("\n")[3].strip() == "None"
 
 
-def test_lists(tmp_path_str):
+@pytest.mark.parametrize("container_type", CONTAINER_TYPES)
+def test_lists(tmp_path_str, container_type):
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path_str) as td:
-        init_repo(td, PARAMS)
+        init_container(td, PARAMS, container_type)
 
         result = runner.invoke(cli, args=["query", "params.l[0]"])
         assert result.exit_code == 0
@@ -208,20 +223,22 @@ def test_lists(tmp_path_str):
         assert values == ["0", "1"]
 
 
-def test_list_of_dicts(tmp_path_str):
+@pytest.mark.parametrize("container_type", CONTAINER_TYPES)
+def test_list_of_dicts(tmp_path_str, container_type):
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path_str) as td:
-        init_repo(td, PARAMS)
+        init_container(td, PARAMS, container_type)
 
         result = runner.invoke(cli, args=["query", "params.ld[0].e"])
         assert result.exit_code == 0
         assert result.stdout.split("\n")[7].strip() == "f"
 
 
-def test_filter(tmp_path_str):
+@pytest.mark.parametrize("container_type", CONTAINER_TYPES)
+def test_filter(tmp_path_str, container_type):
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path_str) as td:
-        init_repo(td, PARAMS)
+        init_container(td, PARAMS, container_type)
 
         result = runner.invoke(
             cli, args=["query", "params.a.b", "filter", "params.a.b is not None"]
@@ -236,10 +253,11 @@ def test_filter(tmp_path_str):
         assert result.exit_code == 0
 
 
-def test_sort(tmp_path_str):
+@pytest.mark.parametrize("container_type", CONTAINER_TYPES)
+def test_sort(tmp_path_str, container_type):
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path_str) as td:
-        init_repo(td, PARAMS)
+        init_container(td, PARAMS, container_type)
 
         result = runner.invoke(cli, args=["query", "params.ord", "sort", "params.ord"])
         assert result.exit_code == 0
@@ -252,10 +270,11 @@ def test_sort(tmp_path_str):
         assert result.stdout.split("\n")[3].strip() == "6"
 
 
-def test_advanced_sort(tmp_path_str):
+@pytest.mark.parametrize("container_type", CONTAINER_TYPES)
+def test_advanced_sort(tmp_path_str, container_type):
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path_str) as td:
-        init_repo(td, PARAMS)
+        init_container(td, PARAMS, container_type)
 
         result = runner.invoke(cli, args=["query", "params.a.b", "sort", "params.a.b"])
         assert result.exit_code == 0
@@ -269,18 +288,20 @@ def test_advanced_sort(tmp_path_str):
         assert result.exit_code == 0
 
 
-def test_corrupted_model_meta(tmp_path_str):
+@pytest.mark.parametrize("container_type", CONTAINER_TYPES)
+def test_corrupted_model_meta(tmp_path_str, container_type):
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path_str) as td:
-        init_repo(td, PARAMS)
-        corrupt_model_meta(td)
+        init_container(td, PARAMS, container_type)
+        corrupt_model_meta(td, container_type)
 
         result = runner.invoke(cli, args=["query", "params.a.b"])
         assert result.exit_code == 0
         assert result.stdout.split("\n")[3].strip() == "None"
 
 
-def test_will_not_execute_dangerous_op(tmp_path_str):
+@pytest.mark.parametrize("container_type", CONTAINER_TYPES)
+def test_will_not_execute_dangerous_op(tmp_path_str, container_type):
     runner = CliRunner()
 
     def assert_will_not_execute(query_list, message):
@@ -293,7 +314,7 @@ def test_will_not_execute_dangerous_op(tmp_path_str):
         assert message in result.exc_info[1].args[0]
 
     with runner.isolated_filesystem(temp_dir=tmp_path_str) as td:
-        init_repo(td, PARAMS)
+        init_container(td, PARAMS, container_type)
 
         assert_will_not_execute(
             [

--- a/cascade/tests/cli/test_query.py
+++ b/cascade/tests/cli/test_query.py
@@ -23,7 +23,7 @@ from click.testing import CliRunner
 SCRIPT_DIR = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
 sys.path.append(os.path.dirname(SCRIPT_DIR))
 from cascade.cli.cli import cli
-from cascade.cli.query import Field, QueryParsingError, empty_field
+from cascade.cli.query import Field, QueryParsingError, QueryExecutionError, empty_field
 from cascade.tests.cli.common import init_repo
 
 PARAMS = [
@@ -50,7 +50,9 @@ def test_parsing(tmp_path_str):
         result = runner.invoke(cli, args=["query", "params"])
         assert result.exit_code == 0
 
-        result = runner.invoke(cli, args=["query", "params", "filter", "params is not None"])
+        result = runner.invoke(
+            cli, args=["query", "params", "filter", "params is not None"]
+        )
         assert result.exit_code == 0
 
         result = runner.invoke(
@@ -158,7 +160,9 @@ def test_parsing_error(tmp_path_str):
         assert result.exit_code == 1
         assert type(result.exception) is QueryParsingError
 
-        result = runner.invoke(cli, args=["query", "metrics", "sort", "metrics[0]", "filter"])
+        result = runner.invoke(
+            cli, args=["query", "metrics", "sort", "metrics[0]", "filter"]
+        )
         assert result.exit_code == 1
         assert type(result.exception) is QueryParsingError
 
@@ -225,7 +229,9 @@ def test_filter(tmp_path_str):
         assert result.stdout.split("\n")[3].strip() == "0"
         assert result.exit_code == 0
 
-        result = runner.invoke(cli, args=["query", "params.l[0]", "filter", "params.l[0] > 0"])
+        result = runner.invoke(
+            cli, args=["query", "params.l[0]", "filter", "params.l[0] > 0"]
+        )
         assert result.stdout.split("\n")[3].strip() == "1"
         assert result.exit_code == 0
 
@@ -239,7 +245,9 @@ def test_sort(tmp_path_str):
         assert result.exit_code == 0
         assert result.stdout.split("\n")[3].strip() == "0"
 
-        result = runner.invoke(cli, args=["query", "params.ord", "sort", "params.ord", "desc"])
+        result = runner.invoke(
+            cli, args=["query", "params.ord", "sort", "params.ord", "desc"]
+        )
         assert result.exit_code == 0
         assert result.stdout.split("\n")[3].strip() == "6"
 
@@ -255,7 +263,9 @@ def test_advanced_sort(tmp_path_str):
         result = runner.invoke(cli, args=["query", "params.l", "sort", "params.l[0]"])
         assert result.exit_code == 0
 
-        result = runner.invoke(cli, args=["query", "params.l[1]", "sort", "params.l[1]"])
+        result = runner.invoke(
+            cli, args=["query", "params.l[1]", "sort", "params.l[1]"]
+        )
         assert result.exit_code == 0
 
 
@@ -270,6 +280,56 @@ def test_corrupted_model_meta(tmp_path_str):
         assert result.stdout.split("\n")[3].strip() == "None"
 
 
+def test_will_not_execute_dangerous_op(tmp_path_str):
+    runner = CliRunner()
+
+    def assert_will_not_execute(query_list, message):
+        result = runner.invoke(
+            cli,
+            args=query_list,
+        )
+        assert result.exit_code == 1
+        assert result.exc_info[0] == QueryExecutionError
+        assert message in result.exc_info[1].args[0]
+
+    with runner.isolated_filesystem(temp_dir=tmp_path_str) as td:
+        init_repo(td, PARAMS)
+
+        assert_will_not_execute(
+            [
+                "query",
+                "__import__('subprocess').Popen('ls')",
+            ],
+            "dangerous method",
+        )
+
+        assert_will_not_execute(
+            [
+                "query",
+                "a, b",
+                "filter",
+                "__import__('subprocess').Popen('ls')",
+            ],
+            "dangerous method",
+        )
+
+        assert_will_not_execute(
+            [
+                "query",
+                "[[[__import__('subprocess').Popen('ls')]]]",
+            ],
+            "dangerous method",
+        )
+
+        assert_will_not_execute(
+            [
+                "query",
+                "__import__('subprocess').Popen('ls')",
+            ],
+            "dangerous method",
+        )
+
+
 def test_empty_field():
     assert empty_field("a") == Field({"a": None})
     assert empty_field("a.b") == Field({"a": {"b": None}})
@@ -281,3 +341,4 @@ def test_field():
     assert f.params.a == 0
     assert f.l[0] == 1
     assert f.no is None
+    assert f.params.no is None

--- a/cascade/tests/cli/test_query.py
+++ b/cascade/tests/cli/test_query.py
@@ -340,3 +340,19 @@ def test_query_preserves_line_type(tmp_path_str):
 
         assert model_line_meta[0]["type"] == "model_line"
         assert data_line_meta[0]["type"] == "data_line"
+
+
+def test_query_with_data_line(tmp_path_str):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path_str) as td:
+        repo = Repo(td)
+
+        ds = Wrapper([])
+        ds.update_meta({"a": 1})
+
+        repo.add_line("datasets", line_type="data").save(ds)
+
+        result = runner.invoke(cli, args=["query", "a"])
+        assert result.exit_code == 0
+        assert result.stdout.split("\n")[3].strip() == "1"
+        assert result.stdout.split("\n")[6] == "Returned rows: 1"

--- a/cascade/tests/cli/test_query.py
+++ b/cascade/tests/cli/test_query.py
@@ -43,9 +43,9 @@ def corrupt_model_meta(root, container_type):
     if container_type == "model_line":
         path = os.path.join(root, "00000", "meta.json")
     elif container_type == "repo":
-        path = os.path.join(root, "line", "00000", "meta.json")
+        path = os.path.join(root, "model_line", "00000", "meta.json")
     elif container_type == "workspace":
-        path = os.path.join(root, "repo", "line", "00000", "meta.json")
+        path = os.path.join(root, "repo", "model_line", "00000", "meta.json")
     else:
         raise ValueError(f"Unknown container type: {container_type}")
 

--- a/cascade/tests/cli/test_query.py
+++ b/cascade/tests/cli/test_query.py
@@ -306,57 +306,6 @@ def test_corrupted_model_meta(tmp_path_str, container_type):
         assert result.stdout.split("\n")[3].strip() == "None"
 
 
-@pytest.mark.parametrize("container_type", CONTAINER_TYPES)
-def test_will_not_execute_dangerous_op(tmp_path_str, container_type):
-    runner = CliRunner()
-
-    def assert_will_not_execute(query_list, message):
-        result = runner.invoke(
-            cli,
-            args=query_list,
-        )
-        assert result.exit_code == 1
-        assert result.exc_info[0] == QueryExecutionError
-        assert message in result.exc_info[1].args[0]
-
-    with runner.isolated_filesystem(temp_dir=tmp_path_str) as td:
-        init_container(td, PARAMS, container_type)
-
-        assert_will_not_execute(
-            [
-                "query",
-                "__import__('subprocess').Popen('ls')",
-            ],
-            "dangerous method",
-        )
-
-        assert_will_not_execute(
-            [
-                "query",
-                "a, b",
-                "filter",
-                "__import__('subprocess').Popen('ls')",
-            ],
-            "dangerous method",
-        )
-
-        assert_will_not_execute(
-            [
-                "query",
-                "[[[__import__('subprocess').Popen('ls')]]]",
-            ],
-            "dangerous method",
-        )
-
-        assert_will_not_execute(
-            [
-                "query",
-                "__import__('subprocess').Popen('ls')",
-            ],
-            "dangerous method",
-        )
-
-
 def test_empty_field():
     assert empty_field("a") == Field({"a": None})
     assert empty_field("a.b") == Field({"a": {"b": None}})

--- a/cascade/tests/cli/test_query.py
+++ b/cascade/tests/cli/test_query.py
@@ -23,8 +23,12 @@ from click.testing import CliRunner
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
 sys.path.append(os.path.dirname(SCRIPT_DIR))
+from cascade.base import MetaHandler
 from cascade.cli.cli import cli
 from cascade.cli.query import Field, QueryParsingError, QueryExecutionError, empty_field
+from cascade.repos import Repo
+from cascade.models import BasicModel
+from cascade.data import Wrapper
 from cascade.tests.cli.common import init_container
 
 CONTAINER_TYPES = ["workspace", "repo", "model_line"]
@@ -318,3 +322,21 @@ def test_field():
     assert f.l[0] == 1
     assert f.no is None
     assert f.params.no is None
+
+
+def test_query_preserves_line_type(tmp_path_str):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path_str) as td:
+        repo = Repo(td)
+        repo.add_line("models", line_type="model").save(BasicModel())
+        repo.add_line("datasets", line_type="data").save(Wrapper([]))
+
+        result = runner.invoke(cli, args=["query", "params.a.b"])
+        assert result.exit_code == 0
+        assert result.stdout.split("\n")[7] == "Returned rows: 2"
+
+        model_line_meta = MetaHandler.read_dir(os.path.join(td, "models"))
+        data_line_meta = MetaHandler.read_dir(os.path.join(td, "datasets"))
+
+        assert model_line_meta[0]["type"] == "model_line"
+        assert data_line_meta[0]["type"] == "data_line"

--- a/cascade/tests/cli/test_query.py
+++ b/cascade/tests/cli/test_query.py
@@ -186,19 +186,21 @@ def test_columns(tmp_path_str, container_type):
     with runner.isolated_filesystem(temp_dir=tmp_path_str) as td:
         init_container(td, PARAMS, container_type)
 
+        results_line_idx = 3 if container_type == "model_line" else 4
+
         result = runner.invoke(cli, args=["query", "params"])
-        assert result.stdout.split("\n")[3].strip() == str(
+        assert result.exit_code == 0
+        assert result.stdout.split("\n")[results_line_idx].strip() == str(
             {"a": {"b": 0}, "l": [0, 1, 2, 3], "ord": 0}
         )
-        assert result.exit_code == 0
 
         result = runner.invoke(cli, args=["query", "params.a.b"])
         assert result.exit_code == 0
-        assert result.stdout.split("\n")[3].strip() == "0"
+        assert result.stdout.split("\n")[results_line_idx].strip() == "0"
 
         result = runner.invoke(cli, args=["query", "params.c.d.e"])
         assert result.exit_code == 0
-        assert result.stdout.split("\n")[3].strip() == "None"
+        assert result.stdout.split("\n")[results_line_idx].strip() == "None"
 
 
 @pytest.mark.parametrize("container_type", CONTAINER_TYPES)
@@ -207,17 +209,19 @@ def test_lists(tmp_path_str, container_type):
     with runner.isolated_filesystem(temp_dir=tmp_path_str) as td:
         init_container(td, PARAMS, container_type)
 
+        results_line_idx = 3 if container_type == "model_line" else 4
+
         result = runner.invoke(cli, args=["query", "params.l[0]"])
         assert result.exit_code == 0
-        assert result.stdout.split("\n")[3].strip() == "0"
+        assert result.stdout.split("\n")[results_line_idx].strip() == "0"
 
         result = runner.invoke(cli, args=["query", "params.ll[0][0]"])
         assert result.exit_code == 0
-        assert result.stdout.split("\n")[8].strip() == "0"
+        assert result.stdout.split("\n")[results_line_idx + 5].strip() == "0"
 
         result = runner.invoke(cli, args=["query", "params.l[0]", "params.l[1]"])
         assert result.exit_code == 0
-        result_line = result.stdout.split("\n")[3]
+        result_line = result.stdout.split("\n")[results_line_idx]
         result_line = re.sub(r"\s+", " ", result_line).strip()
         values = result_line.split(" ")
         assert values == ["0", "1"]
@@ -229,9 +233,11 @@ def test_list_of_dicts(tmp_path_str, container_type):
     with runner.isolated_filesystem(temp_dir=tmp_path_str) as td:
         init_container(td, PARAMS, container_type)
 
+        results_line_idx = 7 if container_type == "model_line" else 8
+
         result = runner.invoke(cli, args=["query", "params.ld[0].e"])
         assert result.exit_code == 0
-        assert result.stdout.split("\n")[7].strip() == "f"
+        assert result.stdout.split("\n")[results_line_idx].strip() == "f"
 
 
 @pytest.mark.parametrize("container_type", CONTAINER_TYPES)

--- a/cascade/tests/cli/test_query_executor.py
+++ b/cascade/tests/cli/test_query_executor.py
@@ -38,7 +38,10 @@ from cascade.tests.cli.common import init_repo
             [{"a": 1}, {"b": 1}],
             Query(columns=["params.a"]),
             Result(
-                columns=["params.a"], rows=2, data=[{"params.a": 1}, {"params.a": None}], time_s=0
+                columns=["params.a"],
+                rows=2,
+                data=[{"params.a": 1}, {"params.a": None}],
+                time_s=0,
             ),
         ),
         (
@@ -67,7 +70,10 @@ from cascade.tests.cli.common import init_repo
             Result(
                 columns=["[params.a, params.b]"],
                 rows=2,
-                data=[{"[params.a, params.b]": [1, None]}, {"[params.a, params.b]": [None, 2]}],
+                data=[
+                    {"[params.a, params.b]": [1, None]},
+                    {"[params.a, params.b]": [None, 2]},
+                ],
                 time_s=0,
             ),
         ),
@@ -91,6 +97,30 @@ from cascade.tests.cli.common import init_repo
                 rows=1,
                 data=[
                     {"min(params.a)": 0},
+                ],
+                time_s=0,
+            ),
+        ),
+        (
+            [{"a": [0, 1, 2]}],
+            Query(columns=["sum(params.a)"]),
+            Result(
+                columns=["sum(params.a)"],
+                rows=1,
+                data=[
+                    {"sum(params.a)": 3},
+                ],
+                time_s=0,
+            ),
+        ),
+        (
+            [{"a": 1}],
+            Query(columns=["-params.a"]),
+            Result(
+                columns=["-params.a"],
+                rows=1,
+                data=[
+                    {"-params.a": -1},
                 ],
                 time_s=0,
             ),
@@ -161,7 +191,10 @@ from cascade.tests.cli.common import init_repo
         (
             [{"a": "1", "b": 0}, {"a": "2", "b": 1}],
             Query(
-                columns=["params.a"], filter_expr="params.a != '1'", sort_expr="params.b", desc=True
+                columns=["params.a"],
+                filter_expr="params.a != '1'",
+                sort_expr="params.b",
+                desc=True,
             ),
             Result(
                 columns=["params.a"],
@@ -190,10 +223,24 @@ from cascade.tests.cli.common import init_repo
                 time_s=0,
             ),
         ),
+        (
+            [{"a": [0, 1, 2]}],
+            Query(
+                columns=["[1 * item ** 1 + 1 for item in params.a]"],
+            ),
+            Result(
+                columns=["[1 * item ** 1 + 1 for item in params.a]"],
+                rows=1,
+                data=[
+                    {"[1 * item ** 1 + 1 for item in params.a]": [1, 2, 3]},
+                ],
+                time_s=0,
+            ),
+        ),
     ],
 )
 def test_params_queries(tmp_path_str, params, query, result):
-    init_repo(tmp_path_str, params)
+    init_repo(tmp_path_str, params, with_data_line=False)
 
     executor = Executor(tmp_path_str, "repo")
     test_result = executor.execute(query)
@@ -206,16 +253,114 @@ def test_params_queries(tmp_path_str, params, query, result):
 @pytest.mark.parametrize(
     "params, query",
     [
-        ([{}, {}, {}], Query(columns=["open('file.txt')"])),
+        ([], Query(columns=["().__class__.__mro__[1].__subclasses__()"])),
         ([{}, {}, {}], Query(columns=["import os"])),
-        ([{}, {}, {}], Query(columns=["from subprocess import Popen"])),
-        ([{}, {}, {}], Query(columns=["eval('print()')"])),
-        ([{}, {}, {}], Query(columns=["exec('echo')"])),
-        ([{}, {}, {}], Query(columns=["def f(): return 0"])),
+        ([{}, {}, {}], Query(columns=["lambda x: x"])),
+        ([{}, {}, {}], Query(columns=["__import__"])),
+        ([{}, {}, {}], Query(columns=["__import__('subprocess').Popen('ls')"])),
+        ([{}, {}, {}], Query(columns=["().__class__.__mro__[1].__subclasses__()"])),
+        ([{}, {}, {}], Query(columns=["().__class__.__base__.__subclasses__()"])),
+        ([{}, {}, {}], Query(columns=["().__class__.__bases__[0].__subclasses__()"])),
+        ([{}, {}, {}], Query(columns=["(lambda: 0).__globals__"])),
     ],
 )
-def test_dangerous_builtins(tmp_path_str: str, params: List[dict], query: Query):
-    init_repo(tmp_path_str, params)
+def test_dangerous_ops_in_columns(tmp_path_str: str, params: List[dict], query: Query):
+    init_repo(tmp_path_str, params, with_data_line=False)
+
+    executor = Executor(tmp_path_str, "repo")
+    with pytest.raises(QueryExecutionError):
+        executor.execute(query)
+
+
+@pytest.mark.parametrize(
+    "params, query",
+    [
+        ([{}, {}, {}], Query(columns=["params.a"], filter_expr="import os")),
+        ([{}, {}, {}], Query(columns=["params.a"], filter_expr="lambda x: x")),
+        ([{}, {}, {}], Query(columns=["params.a"], filter_expr="__import__")),
+        (
+            [{}, {}, {}],
+            Query(
+                columns=["params.a"],
+                filter_expr="__import__('subprocess').Popen('ls')",
+            ),
+        ),
+        (
+            [{}, {}, {}],
+            Query(
+                columns=["params.a"],
+                filter_expr="().__class__.__mro__[1].__subclasses__()",
+            ),
+        ),
+        (
+            [{}, {}, {}],
+            Query(
+                columns=["params.a"],
+                filter_expr="().__class__.__base__.__subclasses__()",
+            ),
+        ),
+        (
+            [{}, {}, {}],
+            Query(
+                columns=["params.a"],
+                filter_expr="().__class__.__bases__[0].__subclasses__()",
+            ),
+        ),
+        (
+            [{}, {}, {}],
+            Query(columns=["params.a"], filter_expr="(lambda: 0).__globals__"),
+        ),
+    ],
+)
+def test_dangerous_ops_in_filter(tmp_path_str: str, params: List[dict], query: Query):
+    init_repo(tmp_path_str, params, with_data_line=False)
+
+    executor = Executor(tmp_path_str, "repo")
+    with pytest.raises(QueryExecutionError):
+        executor.execute(query)
+
+
+@pytest.mark.parametrize(
+    "params, query",
+    [
+        ([{}, {}, {}], Query(columns=["params.a"], sort_expr="import os")),
+        ([{}, {}, {}], Query(columns=["params.a"], sort_expr="lambda x: x")),
+        ([{}, {}, {}], Query(columns=["params.a"], sort_expr="__import__")),
+        (
+            [{}, {}, {}],
+            Query(
+                columns=["params.a"], sort_expr="__import__('subprocess').Popen('ls')"
+            ),
+        ),
+        (
+            [{}, {}, {}],
+            Query(
+                columns=["params.a"],
+                sort_expr="().__class__.__mro__[1].__subclasses__()",
+            ),
+        ),
+        (
+            [{}, {}, {}],
+            Query(
+                columns=["params.a"],
+                sort_expr="().__class__.__base__.__subclasses__()",
+            ),
+        ),
+        (
+            [{}, {}, {}],
+            Query(
+                columns=["params.a"],
+                sort_expr="().__class__.__bases__[0].__subclasses__()",
+            ),
+        ),
+        (
+            [{}, {}, {}],
+            Query(columns=["params.a"], sort_expr="(lambda: 0).__globals__"),
+        ),
+    ],
+)
+def test_dangerous_ops_in_sort(tmp_path_str: str, params: List[dict], query: Query):
+    init_repo(tmp_path_str, params, with_data_line=False)
 
     executor = Executor(tmp_path_str, "repo")
     with pytest.raises(QueryExecutionError):

--- a/cascade/tests/cli/test_query_executor.py
+++ b/cascade/tests/cli/test_query_executor.py
@@ -237,6 +237,52 @@ from cascade.tests.cli.common import init_repo
                 time_s=0,
             ),
         ),
+        (
+            [{"a": [0, 1, 2]}],
+            Query(
+                columns=[
+                    "[bool(item) and bool(item) or not bool(item) and item > 1 and item < 1 for item in params.a if item == 1]"
+                ],
+            ),
+            Result(
+                columns=[
+                    "[bool(item) and bool(item) or not bool(item) and item > 1 and item < 1 for item in params.a if item == 1]"
+                ],
+                rows=1,
+                data=[
+                    {
+                        "[bool(item) and bool(item) or not bool(item) and item > 1 and item < 1 for item in params.a if item == 1]": [
+                            True
+                        ]
+                    }
+                ],
+                time_s=0,
+            ),
+        ),
+        (
+            [{"a": {"b": "c"}}],
+            Query(
+                columns=["params.a.b"],
+            ),
+            Result(
+                columns=["params.a.b"],
+                rows=1,
+                data=[{"params.a.b": "c"}],
+                time_s=0,
+            ),
+        ),
+        (
+            [{"a": {"b": "c"}}],
+            Query(
+                columns=["params.a.b", "params.a['b']"],
+            ),
+            Result(
+                columns=["params.a.b", "params.a['b']"],
+                rows=1,
+                data=[{"params.a.b": "c", "params.a['b']": None}],
+                time_s=0,
+            ),
+        ),
     ],
 )
 def test_params_queries(tmp_path_str, params, query, result):
@@ -250,118 +296,36 @@ def test_params_queries(tmp_path_str, params, query, result):
     assert test_result == result
 
 
+@pytest.mark.parametrize("params", [[], [{}, {}], [{}, {}, {}]])
 @pytest.mark.parametrize(
-    "params, query",
+    "query",
     [
-        ([], Query(columns=["().__class__.__mro__[1].__subclasses__()"])),
-        ([{}, {}, {}], Query(columns=["import os"])),
-        ([{}, {}, {}], Query(columns=["lambda x: x"])),
-        ([{}, {}, {}], Query(columns=["__import__"])),
-        ([{}, {}, {}], Query(columns=["__import__('subprocess').Popen('ls')"])),
-        ([{}, {}, {}], Query(columns=["().__class__.__mro__[1].__subclasses__()"])),
-        ([{}, {}, {}], Query(columns=["().__class__.__base__.__subclasses__()"])),
-        ([{}, {}, {}], Query(columns=["().__class__.__bases__[0].__subclasses__()"])),
-        ([{}, {}, {}], Query(columns=["(lambda: 0).__globals__"])),
+        "().__class__.__mro__[1].__subclasses__()",
+        "import os",
+        "lambda x: x",
+        "__import__",
+        "__import__('subprocess').Popen('ls')",
+        "().__class__.__mro__[1].__subclasses__()",
+        "().__class__.__base__.__subclasses__()",
+        "().__class__.__bases__[0].__subclasses__()",
+        "(lambda: 0).__globals__",
+        "{}.format()",
+        "{}.format_map({})",
     ],
 )
-def test_dangerous_ops_in_columns(tmp_path_str: str, params: List[dict], query: Query):
+@pytest.mark.parametrize("place", ["columns", "filter", "sort"])
+def test_dangerous_ops(tmp_path_str: str, params: List[dict], query: str, place: str):
     init_repo(tmp_path_str, params, with_data_line=False)
+
+    if place == "columns":
+        query_obj = Query(columns=[query])
+    elif place == "filter":
+        query_obj = Query(columns=[""], filter_expr=query)
+    elif place == "sort":
+        query_obj = Query(columns=[""], sort_expr=query)
+    else:
+        raise NotImplementedError(f"Unknown place {place}")
 
     executor = Executor(tmp_path_str, "repo")
     with pytest.raises(QueryExecutionError):
-        executor.execute(query)
-
-
-@pytest.mark.parametrize(
-    "params, query",
-    [
-        ([{}, {}, {}], Query(columns=["params.a"], filter_expr="import os")),
-        ([{}, {}, {}], Query(columns=["params.a"], filter_expr="lambda x: x")),
-        ([{}, {}, {}], Query(columns=["params.a"], filter_expr="__import__")),
-        (
-            [{}, {}, {}],
-            Query(
-                columns=["params.a"],
-                filter_expr="__import__('subprocess').Popen('ls')",
-            ),
-        ),
-        (
-            [{}, {}, {}],
-            Query(
-                columns=["params.a"],
-                filter_expr="().__class__.__mro__[1].__subclasses__()",
-            ),
-        ),
-        (
-            [{}, {}, {}],
-            Query(
-                columns=["params.a"],
-                filter_expr="().__class__.__base__.__subclasses__()",
-            ),
-        ),
-        (
-            [{}, {}, {}],
-            Query(
-                columns=["params.a"],
-                filter_expr="().__class__.__bases__[0].__subclasses__()",
-            ),
-        ),
-        (
-            [{}, {}, {}],
-            Query(columns=["params.a"], filter_expr="(lambda: 0).__globals__"),
-        ),
-    ],
-)
-def test_dangerous_ops_in_filter(tmp_path_str: str, params: List[dict], query: Query):
-    init_repo(tmp_path_str, params, with_data_line=False)
-
-    executor = Executor(tmp_path_str, "repo")
-    with pytest.raises(QueryExecutionError):
-        executor.execute(query)
-
-
-@pytest.mark.parametrize(
-    "params, query",
-    [
-        ([{}, {}, {}], Query(columns=["params.a"], sort_expr="import os")),
-        ([{}, {}, {}], Query(columns=["params.a"], sort_expr="lambda x: x")),
-        ([{}, {}, {}], Query(columns=["params.a"], sort_expr="__import__")),
-        (
-            [{}, {}, {}],
-            Query(
-                columns=["params.a"], sort_expr="__import__('subprocess').Popen('ls')"
-            ),
-        ),
-        (
-            [{}, {}, {}],
-            Query(
-                columns=["params.a"],
-                sort_expr="().__class__.__mro__[1].__subclasses__()",
-            ),
-        ),
-        (
-            [{}, {}, {}],
-            Query(
-                columns=["params.a"],
-                sort_expr="().__class__.__base__.__subclasses__()",
-            ),
-        ),
-        (
-            [{}, {}, {}],
-            Query(
-                columns=["params.a"],
-                sort_expr="().__class__.__bases__[0].__subclasses__()",
-            ),
-        ),
-        (
-            [{}, {}, {}],
-            Query(columns=["params.a"], sort_expr="(lambda: 0).__globals__"),
-        ),
-    ],
-)
-def test_dangerous_ops_in_sort(tmp_path_str: str, params: List[dict], query: Query):
-    init_repo(tmp_path_str, params, with_data_line=False)
-
-    executor = Executor(tmp_path_str, "repo")
-    with pytest.raises(QueryExecutionError):
-        executor.execute(query)
+        executor.execute(query_obj)


### PR DESCRIPTION
This update covers important aspects of cascade query:
- Adds the ability to query against a Workspace
- Fixed DataLines changing type to ModelLine after a query
- Added the ability to work properly with DataLines
- Improved security of queries - disallowed dunder methods and introduced allowlist of operations