### PR TITLE
Dataset meta fixes

### DIFF
--- a/cascade/base/traceable.py
+++ b/cascade/base/traceable.py
@@ -125,7 +125,7 @@ class Traceable:
             Meta is a list (see Meta type alias) to allow the formation of pipelines.
         """
         meta = {}
-        meta["name"] = repr(self)
+        meta["name"] = f"{type(self).__module__}.{type(self).__qualname__}"
 
         if hasattr(self, "description"):
             meta["description"] = self.description

--- a/cascade/base/traceable.py
+++ b/cascade/base/traceable.py
@@ -223,8 +223,7 @@ class Traceable:
         Returns
         -------
         repr: str
-            Representation of a Traceable. This repr used as a name for get_meta() method
-            by default gives the name of class from basic repr
+            Representation of a Traceable
 
         See also
         --------

--- a/cascade/base/utils.py
+++ b/cascade/base/utils.py
@@ -24,7 +24,7 @@ from coolname import generate
 
 from . import Meta
 
-default_keys = ["data"]
+default_keys = ["data", "dataset"]
 
 
 class Version:
@@ -173,30 +173,17 @@ def update_version(path: str, version: str) -> None:
             return
 
 
-def skeleton(
-    meta: Meta, keys: Optional[List[Any]] = None
-) -> List[List[Dict[Any, Any]]]:
+def skeleton(meta: Meta) -> List[List[Dict[Any, Any]]]:
     """
     Parameters
     ----------
     meta: Meta
         Meta of the pipeline
-    keys: List[Any], optional
-        The set of keys in meta where to search for previous dataset's meta.
-        For example Concatenator when get_meta() is called stores meta of its
-        datasets in the field called 'data'.
-        If nothing given uses the default set of keys. Use this parameter only if
-        your custom modifiers have additional fields you need to cover in this.
 
     Returns
     -------
     skeleton: List[List[Dict[Any, Any]]]
     """
-
-    if keys is not None:
-        keys += default_keys
-    else:
-        keys = default_keys
 
     skel = []
     # The pipeline is given - represent each one with a new list
@@ -212,7 +199,7 @@ def skeleton(
         else:
             raise KeyError("Name not in meta")
 
-        for key in keys:
+        for key in default_keys:
             if key in meta:
                 prev = skeleton(meta[key])
                 s[key] = prev

--- a/cascade/base/utils.py
+++ b/cascade/base/utils.py
@@ -24,7 +24,7 @@ from coolname import generate
 
 from . import Meta
 
-default_keys = ["data", "dataset"]
+default_keys = ["data"]
 
 
 class Version:
@@ -214,7 +214,7 @@ def skeleton(
 
         for key in keys:
             if key in meta:
-                prev = skeleton(meta["data"])
+                prev = skeleton(meta[key])
                 s[key] = prev
         skel.append(s)
     return skel

--- a/cascade/data/functions.py
+++ b/cascade/data/functions.py
@@ -52,15 +52,14 @@ class FunctionModifier(FunctionDataset):
         super().__init__(*converted_args, f=f, **kwargs)
 
     def get_meta(self) -> Meta:
-        meta = super().get_meta()
-        if len(self._datasets) == 1:
-            meta += self._datasets[0].get_meta()
-        elif len(self._datasets) != 0:
-            meta += [[ds.get_meta() for ds in self._datasets]]
-        return meta
+        self_meta = super().get_meta()
+        self_meta[0]["data"] = [ds.get_meta() for ds in self._datasets]
+        return self_meta
 
 
-def dataset(f: Callable[..., Any], do_validate_in: bool = True) -> Callable[..., FunctionDataset]:
+def dataset(
+    f: Callable[..., Any], do_validate_in: bool = True
+) -> Callable[..., FunctionDataset]:
     """
     Thin wrapper to turn any function into a Cascade's Dataset.
     Use this if the function is the data source
@@ -88,7 +87,9 @@ def dataset(f: Callable[..., Any], do_validate_in: bool = True) -> Callable[...,
     return wrapper
 
 
-def modifier(f: Callable[..., Any], do_validate_in: bool = True) -> Callable[..., FunctionModifier]:
+def modifier(
+    f: Callable[..., Any], do_validate_in: bool = True
+) -> Callable[..., FunctionModifier]:
     """
     Thin wrapper to turn any function into Cascade's Modifier
     Pass the returning value of a function

--- a/cascade/lines/disk_line.py
+++ b/cascade/lines/disk_line.py
@@ -126,7 +126,9 @@ class DiskLine(TraceableOnDisk, Line):
         """
         name = self._parse_item_name(path_spec)
         if name is None:
-            raise FileNotFoundError(f"Couldn't find an object {path_spec} in the line {self._root}")
+            raise FileNotFoundError(
+                f"Couldn't find an object {path_spec} in the line {self._root}"
+            )
         return self._read_meta_by_name(name)
 
     def get_item_names(self) -> List[str]:
@@ -148,7 +150,7 @@ class DiskLine(TraceableOnDisk, Line):
         meta[0].update(
             {
                 "root": self._root,
-                "item_cls": repr(self._item_cls),
+                "item_cls": self._item_cls.__qualname__,
                 "len": len(self),
                 "cascade_version": __version__,
             }

--- a/cascade/tests/data/test_functions.py
+++ b/cascade/tests/data/test_functions.py
@@ -47,7 +47,9 @@ def test_modifier():
     assert isinstance(x, FunctionModifier)
     assert x.result == [0, 1, 4]
     meta = x.get_meta()
-    assert len(meta) == 2
+    assert len(meta) == 1
+    assert "data" in meta[0]
+    assert len(meta[0]["data"]) == 1
 
 
 def test_multiple_inputs():
@@ -63,5 +65,6 @@ def test_multiple_inputs():
     assert isinstance(x, FunctionModifier)
     assert x.result == [0, 2, 4]
     meta = x.get_meta()
-    assert len(meta) == 2
-    assert len(meta[1]) == 2  # This means two inputs at the first stage
+    assert len(meta) == 1
+    assert "data" in meta[0]
+    assert len(meta[0]["data"]) == 2

--- a/cascade/tests/lines/test_model_line.py
+++ b/cascade/tests/lines/test_model_line.py
@@ -47,7 +47,7 @@ def test_meta(model_line, dummy_model):
     model_line.save(dummy_model)
     meta = model_line.get_meta()
 
-    assert meta[0]["item_cls"] == repr(DummyModel)
+    assert meta[0]["item_cls"] == "DummyModel"
     assert meta[0]["len"] == 1
 
 
@@ -141,8 +141,12 @@ def test_load_artifact_paths(tmp_path_str, model_line, dummy_model):
     assert "files" in res
     assert len(res["artifacts"]) == 1
     assert len(res["files"]) == 1
-    assert res["artifacts"][0] == os.path.join(model_line.get_root(), "00000", "artifacts", "model")
-    assert res["files"][0] == os.path.join(model_line.get_root(), "00000", "files", "file.txt")
+    assert res["artifacts"][0] == os.path.join(
+        model_line.get_root(), "00000", "artifacts", "model"
+    )
+    assert res["files"][0] == os.path.join(
+        model_line.get_root(), "00000", "files", "file.txt"
+    )
 
 
 def test_create_model(tmp_path_str):
@@ -169,7 +173,9 @@ def test_handle_save_error(tmp_path_str):
     model = Fail2SaveModel()
     line.save(model)
 
-    meta = MetaHandler.read(os.path.join(tmp_path_str, "00000", "meta" + default_meta_format))
+    meta = MetaHandler.read(
+        os.path.join(tmp_path_str, "00000", "meta" + default_meta_format)
+    )
     assert "errors" in meta[0]
     assert "save" in meta[0]["errors"]
 
@@ -188,7 +194,9 @@ def test_handle_save_artifact_error(tmp_path_str):
     model = Fail2SaveArtModel()
     line.save(model)
 
-    meta = MetaHandler.read(os.path.join(tmp_path_str, "00000", "meta" + default_meta_format))
+    meta = MetaHandler.read(
+        os.path.join(tmp_path_str, "00000", "meta" + default_meta_format)
+    )
     assert "errors" in meta[0]
     assert "save_artifact" in meta[0]["errors"]
 


### PR DESCRIPTION
This PR fixes issues connected to meta data
- Fixed FunctionModifier was pushing the bare list in get_meta which violated the schema
- Do not use repr as name in Traceable since it can be user-defined
- Replaces repr methods with name of the class
- Fixed `skeleton` function data key bug