### PR TITLE
General fixes

### DIFF
--- a/cascade/base/traceable.py
+++ b/cascade/base/traceable.py
@@ -429,7 +429,7 @@ class TraceableOnDisk(Traceable):
             if meta_fmt != ext and meta_fmt is not None:
                 warnings.warn(
                     f"Trying to set {meta_fmt} to the object that already has {ext} "
-                    "on path {self._root}",
+                    f"on path {self._root}",
                     stacklevel=2,
                 )
 

--- a/cascade/base/traceable.py
+++ b/cascade/base/traceable.py
@@ -304,7 +304,7 @@ class Traceable:
 
         self.comments.append(comment)
 
-    def remove_comment(self, id: int) -> None:
+    def remove_comment(self, id: str) -> None:
         for i, comment in enumerate(self.comments):
             if comment.id == id:
                 self.comments.pop(i)

--- a/cascade/cli/run.py
+++ b/cascade/cli/run.py
@@ -372,7 +372,6 @@ def run(
             base_cfg = load_config(base)
 
             check_result = can_safely_replace(cfg_dict, base_cfg)
-            print(check_result, f)
             if not check_result.ok and not f:
                 raise Exception(
                     f"Cannot initialize the config in the file using base from {base}."

--- a/cascade/cli/run.py
+++ b/cascade/cli/run.py
@@ -375,7 +375,7 @@ def run(
             if not check_result.ok and not f:
                 raise Exception(
                     f"Cannot initialize the config in the file using base from {base}."
-                    " Base has {check_result.missing_fields} fields, which are missing in"
+                    f" Base has {check_result.missing_fields} fields, which are missing in"
                     " the file's config."
                     " You can update the config in the file, or pass -f flag."
                     " If -f flag is passed it will automatically add missing fields"

--- a/cascade/data/bruteforce_cacher.py
+++ b/cascade/data/bruteforce_cacher.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 from typing import Any
 
-from tqdm import tqdm, trange
+from tqdm import tqdm
 
 from .dataset import BaseDataset, T
 from .modifier import Modifier
@@ -60,9 +60,9 @@ class BruteforceCacher(Modifier[T]):
         super().__init__(dataset, *args, **kwargs)
         # force calling all previous datasets in the init
         if hasattr(self._dataset, "__len__") and hasattr(self._dataset, "__getitem__"):
-            self._data = [self._dataset[i] for i in trange(len(self._dataset))]
+            self._data = [self._dataset[i] for i in range(len(self._dataset))]
         elif hasattr(self._dataset, "__iter__"):
-            self._data = list(tqdm(self._dataset))
+            self._data = list(self._dataset)
         else:
             raise AttributeError(
                 "Input dataset must provide __len__ and __getitem__ or __iter__"

--- a/cascade/lines/model_line.py
+++ b/cascade/lines/model_line.py
@@ -73,9 +73,13 @@ class ModelLine(DiskLine):
                 if slug == slug_from_file:
                     return name
 
-    def _parse_item_name(self, item: Union[int, str]) -> Optional[str]:
+    def _parse_item_name(self, item: Union[int, str]) -> str:
         if isinstance(item, str):
             name = self._find_name_by_slug(item)
+            if not name:
+                raise FileNotFoundError(
+                    f"Failed to find a model with slug={item} in line {self._root}"
+                )
             return name
         else:
             return super()._parse_item_name(item)

--- a/cascade/repos/repo.py
+++ b/cascade/repos/repo.py
@@ -20,10 +20,15 @@ from typing import Any, List, Optional, Union
 
 from typing_extensions import Literal
 
-from ..base import Meta, TraceableOnDisk, ZeroMetaError
+from ..base import Meta, TraceableOnDisk
 from ..lines import Line
 from .base_repo import BaseRepo
 from .line_factory import LineFactory
+
+SHORT_LINE_TYPE_TO_LINE_TYPE = {
+    "model": "model_line",
+    "data": "data_line",
+}
 
 
 class Repo(BaseRepo, TraceableOnDisk):
@@ -190,7 +195,12 @@ class Repo(BaseRepo, TraceableOnDisk):
 
             line_meta = line.get_meta()
 
-            if line_type != line_meta[0]["type"]:
+            if line_type not in SHORT_LINE_TYPE_TO_LINE_TYPE:
+                raise ValueError(
+                    f"line_type={line_type} is not supported, should be one of {list(SHORT_LINE_TYPE_TO_LINE_TYPE.keys())}"
+                )
+
+            if SHORT_LINE_TYPE_TO_LINE_TYPE[line_type] != line_meta[0]["type"]:
                 raise ValueError(
                     f"line_type={line_type} is conflicting with the type saved on disk {line_meta[0]['type']}"
                 )

--- a/cascade/utils/samplers.py
+++ b/cascade/utils/samplers.py
@@ -18,7 +18,6 @@ from itertools import cycle
 from typing import Any, Dict, Optional, Tuple
 
 import numpy as np
-from tqdm import trange
 
 from ..base import Meta
 from ..data.dataset import Dataset, T
@@ -46,7 +45,7 @@ class OverSampler(Sampler[T]):
     def __init__(
         self, dataset: Dataset[Tuple[Any, Any]], *args: Any, **kwargs: Any
     ) -> None:
-        labels = [int(dataset[i][1]) for i in trange(len(dataset))]
+        labels = [int(dataset[i][1]) for i in range(len(dataset))]
         ulabels, counts = np.unique(labels, return_counts=True)
         how_much_add = np.max(counts) - counts
 
@@ -59,7 +58,6 @@ class OverSampler(Sampler[T]):
                 self._add_indices.append(k)
 
         ln = len(dataset) + len(self._add_indices)
-        print(f"Original length was {len(dataset)} and new is {ln}")
 
         super().__init__(dataset, *args, num_samples=ln, **kwargs)
 
@@ -95,7 +93,7 @@ class UnderSampler(Sampler[T]):
     def __init__(
         self, dataset: Dataset[Tuple[Any, Any]], *args: Any, **kwargs: Any
     ) -> None:
-        labels = [int(dataset[i][1]) for i in trange(len(dataset))]
+        labels = [int(dataset[i][1]) for i in range(len(dataset))]
         ulabels, counts = np.unique(labels, return_counts=True)
         min_count = np.min(counts)
 
@@ -109,7 +107,6 @@ class UnderSampler(Sampler[T]):
                 k += 1
 
         ln = len(self._rem_indices)
-        print(f"Original length was {len(dataset)} and new is {ln}")
         super().__init__(dataset, ln, *args, **kwargs)
 
     def get(self, index: int) -> Tuple[Any, Any]:
@@ -159,7 +156,7 @@ class WeighedSampler(Sampler[T]):
                 If some label omitted, assumes that it should be sampled the same number
                 of times it actually appears in the dataset.
         """
-        labels = np.asarray([dataset[i][1] for i in trange(len(dataset))])
+        labels = np.asarray([dataset[i][1] for i in range(len(dataset))])
         ulabels, counts = np.unique(labels, return_counts=True)
         # Convert to lists to prevent serialization problems with metadata
         ulabels, counts = ulabels.tolist(), counts.tolist()
@@ -190,7 +187,6 @@ class WeighedSampler(Sampler[T]):
         assert ln == sum(
             self._partitioning.values()
         ), "The length of the dataset should be equal to the sum of all partitions - possible problem on Cascade side"
-        print(f"Original length was {len(dataset)} and new is {ln}")
         super().__init__(dataset, ln)
 
     def get(self, index: int) -> Tuple[Any, Any]:

--- a/cascade/utils/samplers.py
+++ b/cascade/utils/samplers.py
@@ -157,7 +157,7 @@ class WeighedSampler(Sampler[T]):
             partitioning: Dict[Any, int], optional
                 A dictionary with labels as keys and the number of samples as values.
                 If some label omitted, assumes that it should be sampled the same number
-                of times it is actually appears in the dataset.
+                of times it actually appears in the dataset.
         """
         labels = np.asarray([dataset[i][1] for i in trange(len(dataset))])
         ulabels, counts = np.unique(labels, return_counts=True)
@@ -168,7 +168,8 @@ class WeighedSampler(Sampler[T]):
             partitioning = {}
 
         self._check_partitioning(ulabels, partitioning)
-        self._partitioning = partitioning
+        # Copy partitioning to preserve original as is
+        self._partitioning = dict(partitioning)
 
         # If label is omitted in partitioning, add it with true count
         for ulabel, count in zip(ulabels, counts):
@@ -187,8 +188,8 @@ class WeighedSampler(Sampler[T]):
 
         ln = len(self._indices)
         assert ln == sum(
-            partitioning.values()
-        ), "The length should be equal to the sum of partitions - something went wrong"
+            self._partitioning.values()
+        ), "The length of the dataset should be equal to the sum of all partitions - possible problem on Cascade side"
         print(f"Original length was {len(dataset)} and new is {ln}")
         super().__init__(dataset, ln)
 

--- a/cascade/utils/tables/tables.py
+++ b/cascade/utils/tables/tables.py
@@ -113,17 +113,22 @@ class CSVDataset(TableDataset):
     Wrapper for .csv files.
     """
 
-    def __init__(self, csv_file_path: str, *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self, csv_file_path: str, read_csv_kwargs=None, *args: Any, **kwargs: Any
+    ) -> None:
         """
-        Passes all args and kwargs to ``pd.read_csv``
+        Passes all `read_csv_kwargs` to ``pd.read_csv``
 
         Parameters
         ----------
         csv_file_path:
             path to the .csv file
         """
+
+        read_csv_kwargs = read_csv_kwargs or {}
+
         self._path = csv_file_path
-        t = pd.read_csv(self._path, *args, **kwargs)
+        t = pd.read_csv(self._path, **read_csv_kwargs)
         super().__init__(t=t, **kwargs)
 
 

--- a/cascade/utils/tests/test_weighed_sampler.py
+++ b/cascade/utils/tests/test_weighed_sampler.py
@@ -107,3 +107,26 @@ def test_missing_class():
     # Raise if class is missing in dataset
     with pytest.raises(ValueError):
         ds = WeighedSampler(ds, {"bar": 3, "foo": 2, "spam": 20})
+
+
+def test_weighed_sampler_does_not_mutate_partitioning():
+    # label 0 appears once, label 1 twice; caller specifies only label 0
+    ds = cdd.Wrapper([("a", 0), ("b", 1), ("c", 1)])
+    partitioning = {0: 2}
+
+    WeighedSampler(ds, partitioning)
+
+    # the caller's dict must be left exactly as it was passed
+    assert partitioning == {0: 2}
+
+
+def test_weighed_sampler_partitioning_is_reusable():
+    # the same config applied to two datasets must not leak labels between them
+    cfg = {0: 1}
+
+    ds_a = cdd.Wrapper([("a", 0), ("b", 1)])  # labels 0, 1
+    ds_b = cdd.Wrapper([("x", 0), ("y", 2)])  # labels 0, 2
+
+    WeighedSampler(ds_a, cfg)
+    # today this raises "Label 1 was not found" because cfg was polluted by ds_a
+    WeighedSampler(ds_b, cfg)

--- a/cascade/workspaces/workspace.py
+++ b/cascade/workspaces/workspace.py
@@ -146,11 +146,6 @@ class Workspace(TraceableOnDisk):
         -------
         Repo
             Created repo
-
-        Raises
-        ------
-        ValueError
-            If the repo already exists
         """
         repo = Repo(os.path.join(self._root, name), *args, **kwargs)
         if name not in self._repo_names:


### PR DESCRIPTION
Fixes
- Unintentional debug prints
- Missing format strings
- Line type check in repo used wrong line types
- Wrong type annotation in Traceable.remove_comment
- ModelLine didn't raise error when no model with such slug existed
- Workspace documentation was inconsistent with behavior
- CSVDataset passed same kwargs to super and pandas.read_csv
- WeighedSampler mutated input partitioning dict
- Verbose prints and progress bars in Samlers