### PR TITLE
Replace python with sys.executable

### DIFF
--- a/cascade/cli/run.py
+++ b/cascade/cli/run.py
@@ -300,7 +300,7 @@ class CascadeRun:
         text = script_globals + text
 
         process = subprocess.Popen(
-            ["python", "-u", "-c", text],
+            [sys.executable, "-u", "-c", text],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             env=os.environ,


### PR DESCRIPTION
Use the same python executable for running a script as for running a cli command. Not on every system python is on PATH apparently.