### PR TITLE
Meta fixes

### DIFF
--- a/cascade/base/traceable.py
+++ b/cascade/base/traceable.py
@@ -83,7 +83,7 @@ class Traceable:
 
     def __init__(
         self,
-        *args: Any,  # TODO: why?
+        *args: Any,
         description: Optional[str] = None,
         tags: Optional[Iterable[str]] = None,
         **kwargs: Any,

--- a/cascade/base/utils.py
+++ b/cascade/base/utils.py
@@ -117,7 +117,7 @@ def get_uncommitted_changes() -> Optional[List[str]]:
         )
         result = result.stdout.strip()
         if result != "":
-            return result.split("\n ")
+            return result.splitlines()
         return None
     except Exception:
         return None

--- a/cascade/models/model.py
+++ b/cascade/models/model.py
@@ -17,7 +17,7 @@ limitations under the License.
 import os
 import warnings
 from shutil import copyfile
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Iterable, Optional, Union
 
 import pendulum
 
@@ -33,14 +33,26 @@ class Model(Traceable):
     """
 
     def __init__(
-        self, *args: Any, meta_prefix: Union[Meta, str, None] = None, **kwargs: Any
+        self,
+        *args: Any,
+        meta_prefix: Union[Meta, str, None] = None,
+        description: Optional[str] = None,
+        tags: Optional[Iterable[str]] = None,
+        **kwargs: Any,
     ) -> None:
         """
         Should be called in any successor - initializes default meta needed.
 
         Successors may pass all of their parameters to superclass for it to be able to
-        log them in meta. Everything that is worth to document about the model
-        can be put either in params or meta_prefix
+        log them in meta. Everything that is worth to track about the model
+        can be put in params using this constructor or put in meta directly using update_meta().
+
+        Parameters
+        ----------
+        description : Optional[str], optional
+            by default None
+        tags : Optional[Iterable[str]], optional
+            by default None
         """
         self.metrics = []
         self.params = kwargs
@@ -48,8 +60,15 @@ class Model(Traceable):
         self._file_artifacts_paths = []
         self._file_artifact_missing_oks = []
         self._log_callbacks = []
-        # Model accepts meta_prefix explicitly to not to record it in 'params'
-        super().__init__(*args, meta_prefix=meta_prefix, **kwargs)
+
+        if meta_prefix is not None:
+            warnings.warn(
+                "Use of `meta_prefix` in `__init__` is deprecated since 0.18.0."
+                " Consider using update_meta()",
+                stacklevel=2,
+            )
+
+        super().__init__(*args, description=description, tags=tags, **kwargs)
 
     def fit(self, *args: Any, **kwargs: Any) -> None:
         """

--- a/cascade/repos/single_line_repo.py
+++ b/cascade/repos/single_line_repo.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import os
+import warnings
 from typing import Any, Dict, List, Optional
 
 from typing_extensions import Literal
@@ -35,7 +36,15 @@ class SingleLineRepo(BaseRepo):
         meta_prefix: Optional[Dict[Any, Any]] = None,
         **kwargs: Any,
     ) -> None:
-        super().__init__(line.get_root(), *args, meta_prefix=meta_prefix, **kwargs)
+        super().__init__(line.get_root(), *args, **kwargs)
+
+        if meta_prefix is not None:
+            warnings.warn(
+                "Use of `meta_prefix` in `__init__` is deprecated since 0.18.0."
+                " Consider using update_meta()",
+                stacklevel=2,
+            )
+
         self._lines = {os.path.split(line.get_root())[-1]: {"args": [], "kwargs": {}}}
         self._line = line
 

--- a/cascade/tests/models/test_model.py
+++ b/cascade/tests/models/test_model.py
@@ -94,3 +94,12 @@ def test_add_config(tmp_path_str):
     assert os.path.exists(os.path.join(files_dir, "cascade_run_meta.json"))
     assert os.path.exists(os.path.join(files_dir, "cascade_config.json"))
     assert os.path.exists(os.path.join(files_dir, "cascade_overrides.json"))
+
+
+def test_description_tags():
+    description = "this and tags should not go into params"
+    model = BasicModel(description=description, tags=["hello"])
+
+    assert model.params == {}
+    assert model.tags == {"hello"}
+    assert model.description == description

--- a/cascade/utils/vision/folder_image_dataset.py
+++ b/cascade/utils/vision/folder_image_dataset.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from abc import abstractmethod, ABC
+from abc import ABC, abstractmethod
 from typing import Any
 
 from typing_extensions import Literal

--- a/conftest.py
+++ b/conftest.py
@@ -3,8 +3,8 @@ from doctest import ELLIPSIS
 
 import pytest
 from sybil import Sybil
-from sybil.parsers.codeblock import PythonCodeBlockParser
 from sybil.evaluators.doctest import NUMBER
+from sybil.parsers.codeblock import PythonCodeBlockParser
 from sybil.parsers.doctest import DocTestParser
 from sybil.parsers.rest import SkipParser
 


### PR DESCRIPTION
* Fixes `Model`s did not pass description and tags to `Traceable`
* Deprecates `meta_prefix` in `Model` and `SingleLineRepo`
*  Fixes how `git_uncommitted_changes` is formatted in meta