### PR TITLE
Run update

### DIFF
--- a/cascade/cli/run.py
+++ b/cascade/cli/run.py
@@ -104,8 +104,6 @@ def parse_value(value: ast.expr) -> Any:
 
     if isinstance(value, ast.Constant):
         return value.value
-    elif isinstance(value, ast.Call):
-        return str(value.func.id) + "()"
     elif isinstance(value, ast.List):
         return [parse_value(v) for v in value.elts]
     elif isinstance(value, ast.Tuple):

--- a/cascade/cli/run.py
+++ b/cascade/cli/run.py
@@ -45,9 +45,13 @@ class ConfigFieldCheckResult:
 def cascade_config_imported(tree: ast.Module) -> bool:
     for node in tree.body:
         if isinstance(node, ast.ImportFrom):
-            if node.module == "cascade.base.config" and node.names[0].name == "Config":
+            if node.module == "cascade.base.config" and any(
+                alias.name == "Config" for alias in node.names
+            ):
                 return True
-            if node.module == "cascade.base" and node.names[0].name == "Config":
+            if node.module == "cascade.base" and any(
+                alias.name == "Config" for alias in node.names
+            ):
                 return True
     return False
 

--- a/cascade/tests/cli/test_run.py
+++ b/cascade/tests/cli/test_run.py
@@ -131,8 +131,27 @@ def test_different_types(tmp_path_str: str):
     assert result.exit_code == 0
     assert result.stdout.endswith(
         "[<class 'int'>, <class 'float'>, <class 'str'>, <class 'list'>,"
-        " <class 'dict'>, <class 'set'>, <class 'str'>, <class 'list'>, <class 'tuple'>]\n"
+        " <class 'dict'>, <class 'set'>, <class 'str'>, <class 'list'>,"
+        " <class 'tuple'>]\n"
     )
+
+
+def test_unsupported_types(tmp_path_str: str):
+    script = "\n".join(
+        [
+            "from cascade.base import Config",
+            "class ThisConfig(Config):",
+            "    j = dict()",
+            "print([type(item) for item in ThisConfig().to_dict().values()])",
+        ]
+    )
+
+    path = write_script(script, tmp_path_str)
+    result = run_run(path)
+
+    assert result.exit_code == 1
+    assert isinstance(result.exc_info[1], ValueError)
+    assert "Unsupported" in result.exc_info[1].args[0]
 
 
 def test_different_types_override(tmp_path_str: str):

--- a/cascade/tests/cli/test_run.py
+++ b/cascade/tests/cli/test_run.py
@@ -474,3 +474,24 @@ def test_missing_field(tmp_path_str: str, force: bool):
     else:
         result = run_run(path, "--base", f"{tmp_path_str}/line/00000")
         assert result.exit_code == 1
+
+
+def test_two_names_import(tmp_path_str: str):
+    script = "\n".join(
+        [
+            "import os",
+            "from cascade.base import Traceable, Config",
+            "from cascade.models import BasicModel",
+            "from cascade.lines import ModelLine",
+            "class NewConfig(Config):",
+            "    a = 3",
+            "    b = 4",
+            "    c = 5",
+            "cfg = NewConfig()",
+            "print(cfg.to_dict())",
+        ]
+    )
+
+    path = write_script(script, tmp_path_str)
+    result = run_run(path, "--a", "5")
+    assert "{'a': 5, 'b': 4, 'c': 5}" in result.stdout


### PR DESCRIPTION
* Fix cascade run was unable to detect Config when something else was also imported from base
* Stop supporting ast.Call in Configs for now

Previously ast.Call were converted to strings anyway so it is better to explicitly pause the support for now